### PR TITLE
Remove .order(asc) from stream chain.

### DIFF
--- a/TestConsole/Program.cs
+++ b/TestConsole/Program.cs
@@ -27,7 +27,6 @@ namespace TestConsole
 
             server.Operations
                 .Cursor("now")
-                .Order(OrderDirection.ASC)
                 .Stream((sender, response) => { ShowOperationResponse(response); })
                 .Connect();
 


### PR DESCRIPTION
Inconsistently prevents streaming new events