### PR TITLE
change to fix transaction decode when NO tail and memo present

### DIFF
--- a/stellar-dotnet-sdk/xdr/XdrDataInputStream.cs
+++ b/stellar-dotnet-sdk/xdr/XdrDataInputStream.cs
@@ -44,7 +44,8 @@ namespace stellar_dotnet_sdk.xdr
         {
             ReadFixOpaque((uint) count);
             Array.Copy(_bytes, _pos, buffer, offset, count);
-            _pos += count;
+            // This is added in ReadFixOpaque
+            //_pos += count;
         }
 
         /// <summary>
@@ -204,6 +205,11 @@ namespace stellar_dotnet_sdk.xdr
                     throw new IOException("non-zero padding");
 
                 _pos += (int) len + tailLength;
+            }
+            else
+            {
+                // Need to move position forward lentgh of bytes
+                _pos += (int) len;
             }
 
             return result;

--- a/stellar-dotnet-sdk/xdr/XdrDataInputStream.cs
+++ b/stellar-dotnet-sdk/xdr/XdrDataInputStream.cs
@@ -44,8 +44,7 @@ namespace stellar_dotnet_sdk.xdr
         {
             ReadFixOpaque((uint) count);
             Array.Copy(_bytes, _pos, buffer, offset, count);
-            // This is added in ReadFixOpaque
-            //_pos += count;
+            _pos += count;
         }
 
         /// <summary>
@@ -179,7 +178,11 @@ namespace stellar_dotnet_sdk.xdr
         /// <returns></returns>
         public byte[] ReadVarOpaque(uint max)
         {
-            return ReadFixOpaque(CheckedReadLength(max));
+            uint len = CheckedReadLength(max);
+            byte[] returnValue = ReadFixOpaque(len);
+            var tail = len % 4u;
+            if(tail == 0) _pos += (int) len;
+            return returnValue;
         }
 
         /// <summary>
@@ -205,11 +208,6 @@ namespace stellar_dotnet_sdk.xdr
                     throw new IOException("non-zero padding");
 
                 _pos += (int) len + tailLength;
-            }
-            else
-            {
-                // Need to move position forward lentgh of bytes
-                _pos += (int) len;
             }
 
             return result;


### PR DESCRIPTION
This change is to fix when the transaction is being decoded and there is a memo present but the tail variable is 0 when the ReadFixOpaque is run - the position is not moved forward on the stream in these cases. -

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
