### PR TITLE
Fix double increment of _pos when decoding DataValue

### DIFF
--- a/stellar-dotnet-sdk-test/xdr/XdrDataStreamTest.cs
+++ b/stellar-dotnet-sdk-test/xdr/XdrDataStreamTest.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using stellar_dotnet_sdk.xdr;
 
 namespace stellar_dotnet_sdk_test.xdr
@@ -39,6 +40,20 @@ namespace stellar_dotnet_sdk_test.xdr
         {
             var memo = "øûý™€♠♣♥†‡µ¢£€";
             Assert.AreEqual(memo, BackAndForthXdrStreaming(memo));
+        }
+
+        [TestMethod]
+        public void ReadFixedLengthOpaqueArray()
+        {
+            var bytes = new byte[] {1, 2, 3, 4, 5, 0, 0, 0, 1};
+            var xdrInputStream = new XdrDataInputStream(bytes);
+            var result = new byte[5];
+            xdrInputStream.Read(result, 0, 5);
+            var expected = new byte[] {1, 2, 3, 4, 5};
+            Assert.IsTrue(expected.SequenceEqual(result));
+
+            var sentinel = xdrInputStream.Read();
+            Assert.AreEqual(1, sentinel);
         }
     }
 }


### PR DESCRIPTION
When decoding DataValue, XdrDataInputStream would move _pos forward
both ReadFixOpaque and Read, resulting in and IndexOutOfRange exception
when decoding data with padding.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Reproducing

I noticed the bug trying to decode (with `Transaction.FromEnvelopeXdr`) this transaction

```
AAAAAPOyEZDfMVqKSzP4Gw9Syuyw/6jd98fCtQ0t2rHCpg0IAAAAZACn6pgAAAABAAAAAAAAAAAAAAABAAAAAAAAAAoAAAADS0VZAAAAAAEAAAAFVkFMVUUAAAAAAAAAAAAAAA==
```

Set a breakpoint in `xdr.ManageDataOp:Decode` and notice how it reads too many bytes, resulting in a exception when decoding `TransactionExt`.

This is my fix, but I'm not too familiar with the Xdr decoder so I hope I didn't mess anything up!