### PR TITLE
Add Threshold property to Operation

### DIFF
--- a/stellar-dotnet-sdk-test/OperationTest.cs
+++ b/stellar-dotnet-sdk-test/OperationTest.cs
@@ -29,6 +29,7 @@ namespace stellar_dotnet_sdk_test
             Assert.AreEqual(source.AccountId, parsedOperation.SourceAccount.AccountId);
             Assert.AreEqual(destination.AccountId, parsedOperation.Destination.AccountId);
             Assert.AreEqual(startingAmount, parsedOperation.StartingBalance);
+            Assert.AreEqual(OperationThreshold.Medium, parsedOperation.Threshold);
 
             Assert.AreEqual(
                 "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAAAAAAA7eBSYbzcL5UKo7oXO24y1ckX+XuCtkDsyNHOp1n1bxAAAAACVAvkAA==",
@@ -58,6 +59,7 @@ namespace stellar_dotnet_sdk_test
             Assert.AreEqual(destination.AccountId, parsedOperation.Destination.AccountId);
             Assert.IsTrue(parsedOperation.Asset is AssetTypeNative);
             Assert.AreEqual(amount, parsedOperation.Amount);
+            Assert.AreEqual(OperationThreshold.Medium, parsedOperation.Threshold);
 
             Assert.AreEqual(
                 "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAEAAAAA7eBSYbzcL5UKo7oXO24y1ckX+XuCtkDsyNHOp1n1bxAAAAAAAAAAAlQL5AA=",
@@ -103,6 +105,7 @@ namespace stellar_dotnet_sdk_test
             Assert.IsTrue(parsedOperation.DestAsset is AssetTypeCreditAlphaNum4);
             Assert.AreEqual(destAmount, parsedOperation.DestAmount);
             Assert.AreEqual(path.Length, parsedOperation.Path.Length);
+            Assert.AreEqual(OperationThreshold.Medium, parsedOperation.Threshold);
 
             Assert.AreEqual(
                 "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAIAAAAAAAAAAAAAA+gAAAAA7eBSYbzcL5UKo7oXO24y1ckX+XuCtkDsyNHOp1n1bxAAAAABVVNEAAAAAACNlYd30HdCuLI54eyYjyX/fDyH9IJWIr/hKDcXKQbq1QAAAAAAAAPoAAAAAgAAAAFVU0QAAAAAACoIKnpnw8rtrfxa276dFZo1C19mDqWXtG4ufhWrLUd1AAAAAlRFU1RURVNUAAAAAAAAAABE/ttVl8BLV0csW/xgXtbXOVf1lMyDluMiafl0IDVFIg==",
@@ -146,6 +149,7 @@ namespace stellar_dotnet_sdk_test
             Assert.IsTrue(parsedOperation.DestAsset is AssetTypeCreditAlphaNum4);
             Assert.AreEqual(destAmount, parsedOperation.DestAmount);
             Assert.AreEqual(0, parsedOperation.Path.Length);
+            Assert.AreEqual(OperationThreshold.Medium, parsedOperation.Threshold);
 
             Assert.AreEqual(
                 "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAIAAAAAAAAAAAAAA+gAAAAA7eBSYbzcL5UKo7oXO24y1ckX+XuCtkDsyNHOp1n1bxAAAAABVVNEAAAAAACNlYd30HdCuLI54eyYjyX/fDyH9IJWIr/hKDcXKQbq1QAAAAAAAAPoAAAAAA==",
@@ -172,6 +176,7 @@ namespace stellar_dotnet_sdk_test
             Assert.AreEqual(source.AccountId, parsedOperation.SourceAccount.AccountId);
             Assert.IsTrue(parsedOperation.Asset is AssetTypeNative);
             Assert.AreEqual(limit, parsedOperation.Limit);
+            Assert.AreEqual(OperationThreshold.Medium, parsedOperation.Threshold);
 
             Assert.AreEqual(
                 "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAYAAAAAf/////////8=",
@@ -200,6 +205,7 @@ namespace stellar_dotnet_sdk_test
             Assert.AreEqual(trustor.AccountId, parsedOperation.Trustor.AccountId);
             Assert.AreEqual(assetCode, parsedOperation.AssetCode);
             Assert.AreEqual(authorize, parsedOperation.Authorize);
+            Assert.AreEqual(OperationThreshold.Low, parsedOperation.Threshold);
 
             Assert.AreEqual(
                 "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAcAAAAA7eBSYbzcL5UKo7oXO24y1ckX+XuCtkDsyNHOp1n1bxAAAAABVVNEQQAAAAE=",
@@ -253,6 +259,7 @@ namespace stellar_dotnet_sdk_test
             Assert.AreEqual(signer.Ed25519.InnerValue, parsedOperation.Signer.Ed25519.InnerValue);
             Assert.AreEqual(signerWeight, parsedOperation.SignerWeight);
             Assert.AreEqual(source.AccountId, parsedOperation.SourceAccount.AccountId);
+            Assert.AreEqual(OperationThreshold.High, parsedOperation.Threshold);
 
             Assert.AreEqual(
                 "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAUAAAABAAAAAO3gUmG83C+VCqO6FztuMtXJF/l7grZA7MjRzqdZ9W8QAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAIAAAABAAAAAwAAAAEAAAAEAAAAAQAAAAtzdGVsbGFyLm9yZwAAAAABAAAAAET+21WXwEtXRyxb/GBe1tc5V/WUzIOW4yJp+XQgNUUiAAAAAQ==",
@@ -401,6 +408,7 @@ namespace stellar_dotnet_sdk_test
             Assert.AreEqual(priceObj.Numerator, 5333399);
             Assert.AreEqual(priceObj.Denominator, 6250000);
             Assert.AreEqual(offerId, parsedOperation.OfferId);
+            Assert.AreEqual(OperationThreshold.Medium, parsedOperation.Threshold);
 
             Assert.AreEqual(
                 "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAMAAAAAAAAAAVVTRAAAAAAARP7bVZfAS1dHLFv8YF7W1zlX9ZTMg5bjImn5dCA1RSIAAAAAAAAAZABRYZcAX14QAAAAAAAAAAE=",
@@ -436,6 +444,7 @@ namespace stellar_dotnet_sdk_test
             Assert.AreEqual(price, parsedOperation.Price);
             Assert.AreEqual(priceObj.Numerator, 36731261);
             Assert.AreEqual(priceObj.Denominator, 12500000);
+            Assert.AreEqual(OperationThreshold.Medium, parsedOperation.Threshold);
 
             Assert.AreEqual(
                 "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAQAAAAAAAAAAVVTRAAAAAAARP7bVZfAS1dHLFv8YF7W1zlX9ZTMg5bjImn5dCA1RSIAAAAAAAAAZAIweX0Avrwg",
@@ -459,6 +468,7 @@ namespace stellar_dotnet_sdk_test
             var parsedOperation = (AccountMergeOperation) Operation.FromXdr(xdr);
 
             Assert.AreEqual(destination.AccountId, parsedOperation.Destination.AccountId);
+            Assert.AreEqual(OperationThreshold.High, parsedOperation.Threshold);
 
             Assert.AreEqual(
                 "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAgAAAAA7eBSYbzcL5UKo7oXO24y1ckX+XuCtkDsyNHOp1n1bxA=",
@@ -481,6 +491,7 @@ namespace stellar_dotnet_sdk_test
 
             Assert.AreEqual("test", parsedOperation.Name);
             Assert.IsTrue(new byte[] {0, 1, 2, 3, 4}.SequenceEqual(parsedOperation.Value));
+            Assert.AreEqual(OperationThreshold.Medium, parsedOperation.Threshold);
 
             Assert.AreEqual(
                 "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAoAAAAEdGVzdAAAAAEAAAAFAAECAwQAAAA=",
@@ -562,6 +573,8 @@ namespace stellar_dotnet_sdk_test
             var parsedOperation = (BumpSequenceOperation) Operation.FromXdr(xdr);
 
             Assert.AreEqual(156L, parsedOperation.BumpTo);
+            Assert.AreEqual(OperationThreshold.Low, parsedOperation.Threshold);
+
             Assert.AreEqual("AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAsAAAAAAAAAnA==", operation.ToXdrBase64());
         }
 

--- a/stellar-dotnet-sdk/AccountMergeOperation.cs
+++ b/stellar-dotnet-sdk/AccountMergeOperation.cs
@@ -18,6 +18,11 @@ namespace stellar_dotnet_sdk
         /// </summary>
         public KeyPair Destination { get; }
 
+        public override OperationThreshold Threshold
+        {
+            get => OperationThreshold.High;
+        }
+
         /// <summary>
         /// Returns the Account Merge XDR Operation Body
         /// </summary>

--- a/stellar-dotnet-sdk/AllowTrustOperation.cs
+++ b/stellar-dotnet-sdk/AllowTrustOperation.cs
@@ -31,6 +31,11 @@ namespace stellar_dotnet_sdk
         /// </summary>
         public bool Authorize { get; }
 
+        public override OperationThreshold Threshold
+        {
+            get => OperationThreshold.Low;
+        }
+
         /// <summary>
         /// Returns the Allow Trust XDR Operation Body
         /// </summary>

--- a/stellar-dotnet-sdk/BumpSequenceOperation.cs
+++ b/stellar-dotnet-sdk/BumpSequenceOperation.cs
@@ -8,6 +8,11 @@ namespace stellar_dotnet_sdk
     {
         public long BumpTo { get; }
 
+        public override OperationThreshold Threshold
+        {
+            get => OperationThreshold.Low;
+        }
+
         public BumpSequenceOperation(long bumpTo)
         {
             BumpTo = bumpTo;

--- a/stellar-dotnet-sdk/Operation.cs
+++ b/stellar-dotnet-sdk/Operation.cs
@@ -15,6 +15,14 @@ namespace stellar_dotnet_sdk
             set => _sourceAccount = value ?? throw new ArgumentNullException(nameof(value), "keypair cannot be null");
         }
 
+        /// <summary>
+        /// Threshold level for the operation.
+        /// </summary>
+        public virtual OperationThreshold Threshold
+        {
+            get => OperationThreshold.Medium;
+        }
+
         public static long ToXdrAmount(string value)
         {
             if (string.IsNullOrEmpty(value))
@@ -67,8 +75,8 @@ namespace stellar_dotnet_sdk
 
         ///<summary>
         ///</summary>
-        /// <returns>new Operation object from Operation XDR object.</returns> 
-        /// <param name="thisXdr">XDR object</param> 
+        /// <returns>new Operation object from Operation XDR object.</returns>
+        /// <param name="thisXdr">XDR object</param>
         public static Operation FromXdr(xdr.Operation thisXdr)
         {
             var body = thisXdr.Body;

--- a/stellar-dotnet-sdk/OperationThreshold.cs
+++ b/stellar-dotnet-sdk/OperationThreshold.cs
@@ -1,0 +1,34 @@
+namespace stellar_dotnet_sdk
+{
+    /// <summary>
+    /// Operation threshold level.
+    /// </summary>
+    public enum OperationThreshold
+    {
+        /// <summary>
+        /// Low security level.
+        /// <seealso cref="AllowTrustOperation"/>
+        /// <seealso cref="BumpSequenceOperation"/>
+        /// </summary>
+        Low = 1,
+
+        /// <summary>
+        /// Medium security level.
+        /// <seealso cref="ChangeTrustOperation"/>
+        /// <seealso cref="CreateAccountOperation"/>
+        /// <seealso cref="CreatePassiveOfferOperation"/>
+        /// <seealso cref="ManageDataOperation"/>
+        /// <seealso cref="ManageOfferOperation"/>
+        /// <seealso cref="PathPaymentOperation"/>
+        /// <seealso cref="PaymentOperation"/>
+        /// </summary>
+        Medium = 2,
+
+        /// <summary>
+        /// High security level.
+        /// <seealso cref="SetOptionsOperation"/>
+        /// <seealso cref="AccountMergeOperation"/>
+        /// </summary>
+        High = 3,
+    }
+}

--- a/stellar-dotnet-sdk/SetOptionsOperation.cs
+++ b/stellar-dotnet-sdk/SetOptionsOperation.cs
@@ -47,6 +47,11 @@ namespace stellar_dotnet_sdk
 
         public int? SignerWeight { get; }
 
+        public override OperationThreshold Threshold
+        {
+            get => OperationThreshold.High;
+        }
+
         public override sdkxdr.Operation.OperationBody ToOperationBody()
         {
             var op = new sdkxdr.SetOptionsOp();


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Changes

I have added a `Threshold` property to operations with values `Low | Medium | High`. In most projects I end up writing extension methods that do this, so I thought it could be an useful addition to the library.

Knowing the threshold level of an operation (and in turn of a transaction) is useful when validating the transaction *before* sending to the network. For example, if you have a multi-sig account that requires a second signature for high threshold operations, the wallet could display an helpful message to the user before submitting the transaction.