### PR TITLE
Add ability to retrieve linked resources

### DIFF
--- a/stellar-dotnet-sdk-test/responses/LinkTest.cs
+++ b/stellar-dotnet-sdk-test/responses/LinkTest.cs
@@ -1,0 +1,73 @@
+using System.IO;
+using System.Threading.Tasks;
+using System.Web;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using stellar_dotnet_sdk.requests;
+using stellar_dotnet_sdk.responses;
+using stellar_dotnet_sdk.responses.operations;
+
+namespace stellar_dotnet_sdk_test.responses
+{
+    [TestClass]
+    public class LinkTest
+    {
+        [TestMethod]
+        public async Task TestLink()
+        {
+            var link = new Link<AccountResponse>(
+                "https://horizon.stellar.org/accounts/GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7");
+            Assert.AreEqual("horizon.stellar.org", link.Uri.Host);
+            Assert.AreEqual("/accounts/GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
+                string.Concat(link.Uri.Segments));
+
+            var jsonResponse = File.ReadAllText(Path.Combine("testdata", "account.json"));
+            var fakeHttpClient = FakeHttpClient.CreateFakeHttpClient(jsonResponse);
+
+            var response = await link.Follow(fakeHttpClient);
+            AccountDeserializerTest.AssertTestData(response);
+        }
+
+        [TestMethod]
+        public void TestTemplatedLink()
+        {
+             var link = new TemplatedLink<OperationResponse>(
+                 "https://horizon.stellar.org/accounts/GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7/operations{?cursor,limit,order}");
+            Assert.AreEqual("horizon.stellar.org", link.Uri.Host);
+            Assert.AreEqual("/accounts/GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7/operations",
+                string.Concat(link.Uri.Segments));
+        }
+
+        [TestMethod]
+        public void TestTemplatedLinkWithQueryParameters()
+        {
+             var link = new TemplatedLink<OperationResponse>(
+                 "https://horizon.stellar.org/accounts/GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7/operations{?cursor,limit,order}");
+             var uri = link.Resolve(new
+             {
+                 limit = 10,
+                 order = OrderDirection.DESC,
+                 cursor = "now"
+             });
+
+             var query = HttpUtility.ParseQueryString(uri.Query);
+             Assert.AreEqual("10", query["limit"]);
+             Assert.AreEqual("desc", query["order"]);
+             Assert.AreEqual("now", query["cursor"]);
+        }
+
+        [TestMethod]
+        public void TestTemplatedLinkWithVariable()
+        {
+            var link = new TemplatedLink<AccountDataResponse>(
+                "https://horizon.stellar.org/accounts/GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7/data/{key}");
+
+            var uri = link.Resolve(new
+            {
+                key = "foobar"
+            });
+
+            Assert.AreEqual("https://horizon.stellar.org/accounts/GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7/data/foobar",
+                uri.ToString());
+        }
+    }
+}

--- a/stellar-dotnet-sdk-test/responses/PathsPageDeserializerTest.cs
+++ b/stellar-dotnet-sdk-test/responses/PathsPageDeserializerTest.cs
@@ -32,7 +32,8 @@ namespace stellar_dotnet_sdk_test.responses
 
         public static void AssertTestData(Page<PathResponse> pathsPage)
         {
-            Assert.IsNotNull(pathsPage.NextPage());
+            Assert.IsNull(pathsPage.NextPage());
+            Assert.IsNull(pathsPage.PreviousPage());
 
             Assert.AreEqual(pathsPage.Records[0].DestinationAmount, "20.0000000");
             Assert.AreEqual(pathsPage.Records[0].DestinationAsset,

--- a/stellar-dotnet-sdk/UriTemplate.cs
+++ b/stellar-dotnet-sdk/UriTemplate.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using stellar_dotnet_sdk.requests;
+
+namespace stellar_dotnet_sdk
+{
+    /// <summary>
+    /// Partial implement of the Uri Template Spec (RFC 6570).
+    ///
+    /// In particular it implements:
+    ///
+    ///  * Query component expressions ( {?var1,var2,...,varn} )
+    ///  * Simple variables ( {var} )
+    /// </summary>
+    internal class UriTemplate
+    {
+        private readonly string _template;
+
+        private enum States
+        {
+            COPYING_LITERALS,
+            PARSING_EXPRESSION
+        }
+
+        public UriTemplate(string template)
+        {
+            _template = template;
+        }
+
+        public Uri Resolve(object parameters)
+        {
+            if (parameters is null)
+            {
+                return Resolve();
+            }
+
+            var parametersDict = new Dictionary<string, object>();
+            var properties = parameters.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            foreach (var propertyInfo in properties)
+            {
+                parametersDict[propertyInfo.Name] = propertyInfo.GetValue(parameters, null);
+            }
+
+            return Resolve(parametersDict);
+        }
+
+        public Uri Resolve(IDictionary<string, object> parameters = null)
+        {
+            var currentState = States.COPYING_LITERALS;
+            var resultBuilder = new StringBuilder();
+            var expressionBuilder = new StringBuilder();
+
+            foreach (var character in _template.ToCharArray())
+            {
+                switch (currentState)
+                {
+                    case States.COPYING_LITERALS:
+                        if (character == '{')
+                        {
+                            currentState = States.PARSING_EXPRESSION;
+                            expressionBuilder.Clear();
+                        }
+                        else if (character == '}')
+                        {
+                            throw new ArgumentException("Malformed template, unexpected }");
+                        }
+                        else
+                        {
+                            resultBuilder.Append(character);
+                        }
+
+                        break;
+                    case States.PARSING_EXPRESSION:
+                        if (character == '}')
+                        {
+                            ProcessExpression(expressionBuilder, resultBuilder, parameters);
+                            currentState = States.COPYING_LITERALS;
+                        }
+                        else
+                        {
+                            expressionBuilder.Append(character);
+                        }
+
+                        break;
+                }
+            }
+
+            if (currentState == States.PARSING_EXPRESSION)
+            {
+                throw new ArgumentException("Malformed template, expecting }");
+            }
+
+            return new Uri(resultBuilder.ToString());
+        }
+
+        private void ProcessExpression(StringBuilder expression, StringBuilder result,
+            IDictionary<string, object> parameters)
+        {
+            if (parameters == null) return;
+            if (expression.Length == 0)
+            {
+                throw new ArgumentException("Malformed template {}");
+            }
+
+            var isQueryParameter = expression[0] == '?';
+            var isFirst = true;
+            var firstIndex = isQueryParameter ? 1 : 0;
+            var varName = new StringBuilder();
+
+            for (int i = firstIndex; i < expression.Length; i++)
+            {
+                var currentChar = expression[i];
+                switch (currentChar)
+                {
+                    case ',':
+                        ProcessVariable(varName.ToString(), isQueryParameter, isFirst, result, parameters);
+                        varName.Clear();
+                        isFirst = false;
+                        break;
+                    default:
+                        varName.Append(currentChar);
+                        break;
+                }
+            }
+            ProcessVariable(varName.ToString(), isQueryParameter, isFirst, result, parameters);
+        }
+
+        private void ProcessVariable(string varName, bool isQueryParameter, bool isFirst, StringBuilder result,
+            IDictionary<string, object> parameters)
+        {
+            if (parameters == null) return;
+            if (!parameters.ContainsKey(varName)) return;
+
+            if (isFirst)
+            {
+                if (isQueryParameter)
+                {
+                    result.Append('?');
+                }
+            }
+            else
+            {
+                if (isQueryParameter)
+                {
+                    result.Append('&');
+                }
+                else
+                {
+                    result.Append(',');
+                }
+            }
+
+            if (isQueryParameter)
+            {
+                result.Append(varName);
+                result.Append("=");
+            }
+
+            var value = parameters[varName];
+
+            if (value is string stringValue)
+            {
+                result.Append(stringValue);
+            }
+            else if (value is OrderDirection order)
+            {
+                result.Append(order.ToString().ToLower());
+            }
+            else
+            {
+                result.Append(value.ToString());
+            }
+        }
+    }
+}

--- a/stellar-dotnet-sdk/responses/AccountDataResponse.cs
+++ b/stellar-dotnet-sdk/responses/AccountDataResponse.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace stellar_dotnet_sdk.responses
 {
-    public class AccountDataResponse
+    public class AccountDataResponse : Response
     {
 
         [JsonProperty(PropertyName = "value")]

--- a/stellar-dotnet-sdk/responses/AccountResponseLinks.cs
+++ b/stellar-dotnet-sdk/responses/AccountResponseLinks.cs
@@ -1,10 +1,15 @@
 ﻿using Newtonsoft.Json;
+using stellar_dotnet_sdk.responses.effects;
+using stellar_dotnet_sdk.responses.operations;
+using stellar_dotnet_sdk.responses.page;
 
 namespace stellar_dotnet_sdk.responses
 {
     public class AccountResponseLinks
     {
-        public AccountResponseLinks(Link effects, Link offers, Link operations, Link self, Link transactions)
+        public AccountResponseLinks(Link<Page<EffectResponse>> effects, Link<Page<OfferResponse>> offers,
+            Link<Page<OperationResponse>> operations, Link<AccountResponse> self,
+            Link<Page<TransactionResponse>> transactions)
         {
             Effects = effects;
             Offers = offers;
@@ -14,17 +19,18 @@ namespace stellar_dotnet_sdk.responses
         }
 
         [JsonProperty(PropertyName = "effects")]
-        public Link Effects { get; private set; }
+        public Link<Page<EffectResponse>> Effects { get; private set; }
 
         [JsonProperty(PropertyName = "offers")]
-        public Link Offers { get; private set; }
+        public Link<Page<OfferResponse>> Offers { get; private set; }
 
         [JsonProperty(PropertyName = "operations")]
-        public Link Operations { get; private set; }
+        public Link<Page<OperationResponse>> Operations { get; private set; }
 
-        [JsonProperty(PropertyName = "self")] public Link Self { get; private set; }
+        [JsonProperty(PropertyName = "self")]
+        public Link<AccountResponse> Self { get; private set; }
 
         [JsonProperty(PropertyName = "transactions")]
-        public Link Transactions { get; private set; }
+        public Link<Page<TransactionResponse>> Transactions { get; private set; }
     }
 }

--- a/stellar-dotnet-sdk/responses/AssetResponseLinks.cs
+++ b/stellar-dotnet-sdk/responses/AssetResponseLinks.cs
@@ -3,17 +3,17 @@
 namespace stellar_dotnet_sdk.responses
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public class AssetResponseLinks
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [JsonProperty(PropertyName = "toml")]
         public Link Toml { get; set; }
 
-        public AssetResponseLinks(Link toml)
+        public AssetResponseLinks(Link<AssetResponse> toml)
         {
             Toml = toml;
         }

--- a/stellar-dotnet-sdk/responses/FriendBotResponseLinks.cs
+++ b/stellar-dotnet-sdk/responses/FriendBotResponseLinks.cs
@@ -5,6 +5,6 @@ namespace stellar_dotnet_sdk.responses
     public class FriendBotResponseLinks
     {
         [JsonProperty(PropertyName = "transaction")]
-        public Link Transaction { get; private set; }
+        public Link<TransactionResponse> Transaction { get; private set; }
     }
 }

--- a/stellar-dotnet-sdk/responses/LedgerResponse.cs
+++ b/stellar-dotnet-sdk/responses/LedgerResponse.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using Newtonsoft.Json;
+using stellar_dotnet_sdk.responses.effects;
+using stellar_dotnet_sdk.responses.operations;
+using stellar_dotnet_sdk.responses.page;
 
 namespace stellar_dotnet_sdk.responses
 {
@@ -74,17 +77,19 @@ namespace stellar_dotnet_sdk.responses
         public class LedgerResponseLinks
         {
             [JsonProperty(PropertyName = "effects")]
-            public Link Effects { get; private set; }
+            public Link<Page<EffectResponse>> Effects { get; private set; }
 
             [JsonProperty(PropertyName = "operations")]
-            public Link Operations { get; private set; }
+            public Link<Page<OperationResponse>> Operations { get; private set; }
 
-            [JsonProperty(PropertyName = "self")] public Link Self { get; private set; }
+            [JsonProperty(PropertyName = "self")]
+            public Link<LedgerResponse> Self { get; private set; }
 
             [JsonProperty(PropertyName = "transactions")]
-            public Link Transactions { get; private set; }
+            public Link<Page<TransactionResponse>> Transactions { get; private set; }
 
-            public LedgerResponseLinks(Link effects, Link operations, Link self, Link transactions)
+            public LedgerResponseLinks(Link<Page<EffectResponse>> effects, Link<Page<OperationResponse>> operations,
+                Link<LedgerResponse> self, Link<Page<TransactionResponse>> transactions)
             {
                 Effects = effects;
                 Operations = operations;

--- a/stellar-dotnet-sdk/responses/Link.cs
+++ b/stellar-dotnet-sdk/responses/Link.cs
@@ -1,40 +1,163 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
+using stellar_dotnet_sdk.requests;
 
 namespace stellar_dotnet_sdk.responses
 {
     public class Link
     {
-        public Link(string href, bool templated)
+        public Link(string href)
         {
             Href = href;
-            Templated = templated;
         }
 
-        [JsonProperty(PropertyName = "href")] public string Href { get; set; }
-
-        [JsonProperty(PropertyName = "templated")]
-        public bool Templated { get; set; }
+        [JsonProperty(PropertyName = "href")]
+        public string Href { get; set; }
 
         [JsonIgnore]
-        public Uri Uri
+        public virtual Uri Uri => new Uri(Href);
+
+        public virtual bool Templated => false;
+    }
+
+    [JsonConverter(typeof(LinkDeserializer))]
+    public class Link<TResponse>  : Link
+        where TResponse : Response
+    {
+        public static Link<TResponse> Create(string href, bool templated)
         {
-            get
+            if (templated)
             {
-                try
-                {
-                    return new Uri(Href);
-                }
-                catch (UriFormatException)
-                {
-                    throw;
-                }
+                return new TemplatedLink<TResponse>(href);
             }
+            return new Link<TResponse>(href);
         }
 
-        public bool IsTemplated()
+        public Link(string href) : base(href)
         {
-            return Templated;
+        }
+
+        /// <summary>
+        /// Resolve template Uri by performing variables substitution.
+        /// </summary>
+        /// <returns></returns>
+        public virtual Uri Resolve() => Uri;
+
+        public virtual Uri Resolve(object parameters) => Uri;
+
+        public virtual Uri Resolve(IDictionary<string, object> parameters) => Uri;
+
+        public Task<TResponse> Follow(HttpClient httpClient, object parameters)
+        {
+            return DoFollow(httpClient, Resolve(parameters));
+        }
+
+        /// <summary>
+        /// Follow the Link, retrieving the linked resource.
+        /// </summary>
+        /// <param name="httpClient"></param>
+        /// <param name="parameters"></param>
+        /// <returns></returns>
+        public Task<TResponse> Follow(HttpClient httpClient, IDictionary<string, object> parameters)
+        {
+            return DoFollow(httpClient, Resolve(parameters));
+        }
+
+        /// <summary>
+        /// Follow the Link, retrieving the linked resource.
+        /// </summary>
+        /// <param name="httpClient"></param>
+        /// <returns></returns>
+        public Task<TResponse> Follow(HttpClient httpClient)
+        {
+            return Follow(httpClient, null);
+        }
+
+        /// <summary>
+        /// Follow the Link, retrieving the linked resource.
+        /// </summary>
+        /// <returns></returns>
+        public Task<TResponse> Follow()
+        {
+            return Follow(new HttpClient());
+        }
+
+        /// <summary>
+        /// Follow the Link, retrieving the linked resource.
+        /// </summary>
+        /// <param name="parameters"></param>
+        /// <returns></returns>
+        public Task<TResponse> Follow(object parameters)
+        {
+            return Follow(new HttpClient(), parameters);
+        }
+
+        /// <summary>
+        /// Follow the Link, retrieving the linked resource.
+        /// </summary>
+        /// <param name="parameters"></param>
+        /// <returns></returns>
+        public Task<TResponse> Follow(IDictionary<string, object> parameters)
+        {
+            return Follow(new HttpClient(), parameters);
+        }
+
+        private async Task<TResponse> DoFollow(HttpClient httpClient, Uri uri)
+        {
+            var responseHandler = new ResponseHandler<TResponse>();
+            var response = await httpClient.GetAsync(uri);
+            return await responseHandler.HandleResponse(response);
+        }
+    }
+
+    public class TemplatedLink<TResponse> : Link<TResponse>
+        where TResponse : Response
+    {
+        private UriTemplate _uriTemplate;
+        public TemplatedLink(string href) : base(href)
+        {
+            _uriTemplate = null;
+        }
+
+        public override Uri Uri => ParseUri()?.Resolve();
+
+        public override bool Templated => true;
+
+        public override Uri Resolve() => ParseUri()?.Resolve();
+
+        /// <summary>
+        /// Resolve template Uri by performing variables substitution.
+        /// </summary>
+        /// <param name="parameters"></param>
+        /// <example>
+        /// <code>
+        /// var uri = link.Resolve(new {
+        ///     limit = 10,
+        ///     order = OrderDirection.DESC
+        /// });
+        /// </code>
+        /// </example>
+        /// <returns></returns>
+        public override Uri Resolve(object parameters) => ParseUri()?.Resolve(parameters);
+
+        /// <summary>
+        /// Resolve template Uri by performing variables substitution.
+        /// </summary>
+        /// <param name="parameters"></param>
+        /// <returns></returns>
+        public override Uri Resolve(IDictionary<string, object> parameters) => ParseUri()?.Resolve(parameters);
+
+
+        private UriTemplate ParseUri()
+        {
+            if (_uriTemplate is null)
+            {
+                _uriTemplate = new UriTemplate(Href);
+            }
+            return _uriTemplate;
         }
     }
 }

--- a/stellar-dotnet-sdk/responses/LinkDeserializer.cs
+++ b/stellar-dotnet-sdk/responses/LinkDeserializer.cs
@@ -1,0 +1,49 @@
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace stellar_dotnet_sdk.responses
+{
+    // We have to use reflection because Newtonsoft.Json does not support generic JsonConverters
+    // https://github.com/JamesNK/Newtonsoft.Json/issues/1332
+    public class LinkDeserializer : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value is Link link)
+            {
+                var jsonObject = new JObject();
+                jsonObject.Add(new JProperty("href", link.Href));
+                if (link.Templated)
+                {
+                    jsonObject.Add(new JProperty("templated", link.Templated));
+                }
+
+                jsonObject.WriteTo(writer);
+            }
+            else
+            {
+                throw new JsonSerializationException();
+            }
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
+            JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null) return null;
+
+            var jsonObject = JObject.Load(reader);
+            var templated = jsonObject.GetValue("templated")?.ToObject<bool>() ?? false;
+            var href = jsonObject.GetValue("href")?.ToObject<string>();
+
+            if (href is null) throw new JsonSerializationException();
+
+            return objectType.GetMethod("Create")?.Invoke(null, new object[] {href, templated});
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Link<>);
+        }
+    }
+}

--- a/stellar-dotnet-sdk/responses/OfferResponseLinks.cs
+++ b/stellar-dotnet-sdk/responses/OfferResponseLinks.cs
@@ -4,15 +4,16 @@ namespace stellar_dotnet_sdk.responses
 {
     public class OfferResponseLinks
     {
-        public OfferResponseLinks(Link self, Link offerMaker)
+        public OfferResponseLinks(Link<OfferResponse> self, Link<AccountResponse> offerMaker)
         {
             Self = self;
             OfferMaker = offerMaker;
         }
 
-        [JsonProperty(PropertyName = "self")] public Link Self { get; private set; }
+        [JsonProperty(PropertyName = "self")]
+        public Link<OfferResponse> Self { get; private set; }
 
         [JsonProperty(PropertyName = "offer_maker")]
-        public Link OfferMaker { get; private set; }
+        public Link<AccountResponse> OfferMaker { get; private set; }
     }
 }

--- a/stellar-dotnet-sdk/responses/Page.cs
+++ b/stellar-dotnet-sdk/responses/Page.cs
@@ -26,25 +26,18 @@ namespace stellar_dotnet_sdk.responses.page
         public List<T> Records => Embedded.Records;
 
         [JsonProperty(PropertyName = "_links")]
-        public PageLinks Links { get; private set; }
+        public PageLinks<T> Links { get; private set; }
+
+        /// <summary>
+        ///     The previous page of results or null when there is no more results
+        /// </summary>
+        /// <returns></returns>
+        public Task<Page<T>> PreviousPage() => Links.Prev?.Follow();
 
         /// <summary>
         ///     The next page of results or null when there is no more results
         /// </summary>
         /// <returns></returns>
-        public async Task<Page<T>> NextPage()
-        {
-            if (Links.Next == null)
-                return null;
-
-            var responseHandler = new ResponseHandler<Page<T>>();
-            var uri = new Uri(Links.Next.Href);
-
-            using (var httpClient = new HttpClient())
-            {
-                var response = await httpClient.GetAsync(uri);
-                return await responseHandler.HandleResponse(response);
-            }
-        }
+        public Task<Page<T>> NextPage() => Links.Next?.Follow();
     }
 }

--- a/stellar-dotnet-sdk/responses/PageLinks.cs
+++ b/stellar-dotnet-sdk/responses/PageLinks.cs
@@ -3,19 +3,19 @@
     /// <summary>
     ///     Links connected to page response.
     /// </summary>
-    public class PageLinks
+    public class PageLinks<T>
     {
-        public PageLinks(Link next, Link prev, Link self)
+        public PageLinks(Link<Page<T>> next, Link<Page<T>> prev, Link<Page<T>> self)
         {
             Next = next;
             Prev = prev;
             Self = self;
         }
 
-        public Link Next { get; }
+        public Link<Page<T>> Next { get; }
 
-        public Link Prev { get; }
+        public Link<Page<T>> Prev { get; }
 
-        public Link Self { get; }
+        public Link<Page<T>> Self { get; }
     }
 }

--- a/stellar-dotnet-sdk/responses/PathResponseLinks.cs
+++ b/stellar-dotnet-sdk/responses/PathResponseLinks.cs
@@ -4,9 +4,10 @@ namespace stellar_dotnet_sdk.responses
 {
     public class PathResponseLinks
     {
-        [JsonProperty(PropertyName = "self")] public Link Self { get; }
+        [JsonProperty(PropertyName = "self")]
+        public Link<PathResponse> Self { get; }
 
-        public PathResponseLinks(Link self)
+        public PathResponseLinks(Link<PathResponse> self)
         {
             Self = self;
         }

--- a/stellar-dotnet-sdk/responses/TradeResponseLinks.cs
+++ b/stellar-dotnet-sdk/responses/TradeResponseLinks.cs
@@ -1,22 +1,24 @@
 ﻿using Newtonsoft.Json;
+using stellar_dotnet_sdk.responses.operations;
 
 namespace stellar_dotnet_sdk.responses
 {
     public class TradeResponseLinks
     {
-        public TradeResponseLinks(Link baseLink, Link counterLink, Link operationLink)
+        public TradeResponseLinks(Link<AssetResponse> baseLink, Link<AssetResponse> counterLink, Link<OperationResponse> operationLink)
         {
             Base = baseLink;
             Counter = counterLink;
             Operation = operationLink;
         }
 
-        [JsonProperty(PropertyName = "base")] public Link Base;
+        [JsonProperty(PropertyName = "base")]
+        public Link<AssetResponse> Base;
 
         [JsonProperty(PropertyName = "counter")]
-        public Link Counter;
+        public Link<AssetResponse> Counter;
 
         [JsonProperty(PropertyName = "operation")]
-        public Link Operation;
+        public Link<OperationResponse> Operation;
     }
 }

--- a/stellar-dotnet-sdk/responses/TransactionResponse.cs
+++ b/stellar-dotnet-sdk/responses/TransactionResponse.cs
@@ -1,5 +1,8 @@
 ﻿using Newtonsoft.Json;
 using System;
+using stellar_dotnet_sdk.responses.effects;
+using stellar_dotnet_sdk.responses.operations;
+using stellar_dotnet_sdk.responses.page;
 
 namespace stellar_dotnet_sdk.responses
 {
@@ -119,26 +122,29 @@ namespace stellar_dotnet_sdk.responses
         public class TransactionResponseLinks
         {
             [JsonProperty(PropertyName = "account")]
-            public Link Account { get; private set; }
+            public Link<AccountResponse> Account { get; private set; }
 
             [JsonProperty(PropertyName = "effects")]
-            public Link Effects { get; private set; }
+            public Link<Page<EffectResponse>> Effects { get; private set; }
 
             [JsonProperty(PropertyName = "ledger")]
-            public Link Ledger { get; private set; }
+            public Link<LedgerResponse> Ledger { get; private set; }
 
             [JsonProperty(PropertyName = "operations")]
-            public Link Operations { get; private set; }
+            public Link<Page<OperationResponse>> Operations { get; private set; }
 
             [JsonProperty(PropertyName = "precedes")]
-            public Link Precedes { get; private set; }
+            public Link<TransactionResponse> Precedes { get; private set; }
 
-            [JsonProperty(PropertyName = "self")] public Link Self { get; private set; }
+            [JsonProperty(PropertyName = "self")]
+            public Link<TransactionResponse> Self { get; private set; }
 
             [JsonProperty(PropertyName = "succeeds")]
-            public Link Succeeds { get; private set; }
+            public Link<TransactionResponse> Succeeds { get; private set; }
 
-            public TransactionResponseLinks(Link account, Link effects, Link ledger, Link operations, Link self, Link precedes, Link succeeds)
+            public TransactionResponseLinks(Link<AccountResponse> account, Link<Page<EffectResponse>> effects,
+                Link<LedgerResponse> ledger, Link<Page<OperationResponse>> operations, Link<TransactionResponse> self,
+                Link<TransactionResponse> precedes, Link<TransactionResponse> succeeds)
             {
                 Account = account;
                 Effects = effects;

--- a/stellar-dotnet-sdk/responses/effects/EffectResponse.cs
+++ b/stellar-dotnet-sdk/responses/effects/EffectResponse.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
+using stellar_dotnet_sdk.responses.operations;
 
 namespace stellar_dotnet_sdk.responses.effects
 {
@@ -33,15 +34,16 @@ namespace stellar_dotnet_sdk.responses.effects
         public class EffectsResponseLinks
         {
             [JsonProperty(PropertyName = "operation")]
-            public Link Operation { get; }
+            public Link<OperationResponse> Operation { get; }
 
             [JsonProperty(PropertyName = "precedes")]
-            public Link Precedes { get; }
+            public Link<EffectResponse> Precedes { get; }
 
             [JsonProperty(PropertyName = "succeeds")]
-            public Link Succeeds { get; }
+            public Link<EffectResponse> Succeeds { get; }
 
-            public EffectsResponseLinks(Link operation, Link precedes, Link succeeds)
+            public EffectsResponseLinks(Link<OperationResponse> operation, Link<EffectResponse> precedes,
+                Link<EffectResponse> succeeds)
             {
                 Operation = operation;
                 Precedes = precedes;

--- a/stellar-dotnet-sdk/responses/operations/OperationResponseLinks.cs
+++ b/stellar-dotnet-sdk/responses/operations/OperationResponseLinks.cs
@@ -1,4 +1,6 @@
 ﻿using Newtonsoft.Json;
+using stellar_dotnet_sdk.responses.effects;
+using stellar_dotnet_sdk.responses.page;
 
 namespace stellar_dotnet_sdk.responses.operations
 {
@@ -15,31 +17,31 @@ namespace stellar_dotnet_sdk.responses.operations
         /// This endpoint represents effects that occurred as a result of a given operation.
         /// </summary>
         [JsonProperty(PropertyName = "effects")]
-        public Link Effects { get; private set; }
+        public Link<Page<EffectResponse>> Effects { get; private set; }
 
         /// <summary>
         /// This endpoint represents precedes that occurred as a result of a given operation.
         /// </summary>
         [JsonProperty(PropertyName = "precedes")]
-        public Link Precedes { get; private set; }
+        public Link<OperationResponse> Precedes { get; private set; }
 
         /// <summary>
         /// This endpoint represents self that occurred as a result of a given operation.
         /// </summary>
         [JsonProperty(PropertyName = "self")]
-        public Link Self { get; private set; }
+        public Link<OperationResponse> Self { get; private set; }
 
         /// <summary>
         /// This endpoint represents succeeds that occurred as a result of a given operation.
         /// </summary>
         [JsonProperty(PropertyName = "succeeds")]
-        public Link Succeeds { get; private set; }
+        public Link<OperationResponse> Succeeds { get; private set; }
 
         /// <summary>
         /// This endpoint represents transaction that occurred as a result of a given operation.
         /// </summary>
         [JsonProperty(PropertyName = "transaction")]
-        public Link Transaction { get; private set; }
+        public Link<TransactionResponse> Transaction { get; private set; }
 
         public OperationResponseLinks()
         {
@@ -54,7 +56,8 @@ namespace stellar_dotnet_sdk.responses.operations
         /// <param name="self">This endpoint represents self that occurred as a result of a given operation.</param>
         /// <param name="succeeds">This endpoint represents succeeds that occurred as a result of a given operation.</param>
         /// <param name="transaction">This endpoint represents transaction that occurred as a result of a given operation.</param>
-        public OperationResponseLinks(Link effects, Link precedes, Link self, Link succeeds, Link transaction)
+        public OperationResponseLinks(Link<Page<EffectResponse>> effects, Link<OperationResponse> precedes,
+            Link<OperationResponse> self, Link<OperationResponse> succeeds, Link<TransactionResponse> transaction)
         {
             Effects = effects;
             Precedes = precedes;


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Summary

This is the PR mentioned in #133. The implementation is pretty straightforward, notice that in `TemplatedLink` I lazily parse the template only when needed. 

I added the following overloads to `Link.Follow`:

 * With and without `HttpClient`, this is needed to play nicely in e.g. ASP.Net applications
 * Without parameters
 * With parameters as `IDictionary<string, object>`
 * With parameters as `object`, this way users can specify the parameters using e.g. anonymous objects