### PR TITLE
Publish stellar-dotnet-sdk-xdr to Nuget

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ before_build:
 - cmd: dotnet restore stellar-dotnet-sdk.sln
 dotnet_csproj:
   patch: true
-  file: stellar-dotnet-sdk.csproj
+  file: 'stellar-dotnet-sdk.csproj;stellar-dotnet-sdk-xdr.csproj'
   version: '{version}'
   package_version: '{version}'
   assembly_version: '{version}'

--- a/stellar-dotnet-sdk-xdr/stellar-dotnet-sdk-xdr.csproj
+++ b/stellar-dotnet-sdk-xdr/stellar-dotnet-sdk-xdr.csproj
@@ -2,17 +2,17 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>2.1.0</Version>
+    <Version>1.0</Version>
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <StartupObject />
     <RootNamespace>stellar_dotnet_sdk_xdr</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Description>The .NET Stellar SDK facilitates client integration with the Stellar Horizon API server and submission of Stellar transactions. It has two main uses: querying Horizon and building, signing, and submitting transactions to the Stellar network.</Description>
+    <Description>The .NET Standard XDR Objects for the Stellar Network Protocol</Description>
     <PackageId>stellar-dotnet-sdk-xdr</PackageId>
-    <PackageLicense>sss</PackageLicense>
+    <PackageLicense></PackageLicense>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-    <Copyright>elucidsoft 2018</Copyright>
+    <Copyright>elucidsoft 2019</Copyright>
     <PackageProjectUrl>https://github.com/elucidsoft/dotnet-stellar-sdk</PackageProjectUrl>
     <RepositoryUrl>https://github.com/elucidsoft/dotnet-stellar-sdk</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/stellar-dotnet-sdk-xdr/stellar-dotnet-sdk-xdr.csproj
+++ b/stellar-dotnet-sdk-xdr/stellar-dotnet-sdk-xdr.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <None Include="..\LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
-
+ 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/stellar-dotnet-sdk-xdr/stellar-dotnet-sdk-xdr.csproj
+++ b/stellar-dotnet-sdk-xdr/stellar-dotnet-sdk-xdr.csproj
@@ -1,9 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
-        <RootNamespace>stellar_dotnet_sdk_xdr</RootNamespace>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>2.1.0</Version>
+    <ApplicationIcon />
+    <OutputType>Library</OutputType>
+    <StartupObject />
+    <RootNamespace>stellar_dotnet_sdk_xdr</RootNamespace>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Description>The .NET Stellar SDK facilitates client integration with the Stellar Horizon API server and submission of Stellar transactions. It has two main uses: querying Horizon and building, signing, and submitting transactions to the Stellar network.</Description>
+    <PackageId>stellar-dotnet-sdk-xdr</PackageId>
+    <PackageLicense>sss</PackageLicense>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <Copyright>elucidsoft 2018</Copyright>
+    <PackageProjectUrl>https://github.com/elucidsoft/dotnet-stellar-sdk</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/elucidsoft/dotnet-stellar-sdk</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>'.NET Core' 'Stellar' 'Horizon' 'Blockchain' 'Crypto' 'Distributed Ledger'</PackageTags>
+    <ReleaseNotes>https://github.com/elucidsoft/dotnet-stellar-sdk/releases</ReleaseNotes>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\LICENSE.txt" Pack="true" PackagePath="" />
+  </ItemGroup>
 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/stellar-dotnet-sdk-xdr/stellar-dotnet-sdk-xdr.csproj
+++ b/stellar-dotnet-sdk-xdr/stellar-dotnet-sdk-xdr.csproj
@@ -13,8 +13,8 @@
     <PackageLicense></PackageLicense>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <Copyright>elucidsoft 2019</Copyright>
-    <PackageProjectUrl>https://github.com/elucidsoft/dotnet-stellar-sdk</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/elucidsoft/dotnet-stellar-sdk</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/elucidsoft/dotnet-stellar-sdk/tree/master/stellar-dotnet-sdk-xdr</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/elucidsoft/dotnet-stellar-sdk/tree/master/stellar-dotnet-sdk-xdr</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>'.NET Core' 'Stellar' 'Horizon' 'Blockchain' 'Crypto' 'Distributed Ledger'</PackageTags>
     <ReleaseNotes>https://github.com/elucidsoft/dotnet-stellar-sdk/releases</ReleaseNotes>

--- a/stellar-dotnet-sdk/stellar-dotnet-sdk.csproj
+++ b/stellar-dotnet-sdk/stellar-dotnet-sdk.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Nett" Version="0.10.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
+  
   <ItemGroup>
     <None Include="..\LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>


### PR DESCRIPTION
At the moment `stellar-dotnet-sdk-xdr` is a nuget dependency of `stellar-dotnet-sdk` but it's not published on nuget. This fixes it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
