### PR TITLE
Make NetworkPassphrase constants public

### DIFF
--- a/stellar-dotnet-sdk/Network.cs
+++ b/stellar-dotnet-sdk/Network.cs
@@ -5,8 +5,8 @@ namespace stellar_dotnet_sdk
 {
     public class Network
     {
-        private static readonly string PUBLIC = "Public Global Stellar Network ; September 2015";
-        private static readonly string TESTNET = "Test SDF Network ; September 2015";
+        public static readonly string PublicPassphrase = "Public Global Stellar Network ; September 2015";
+        public static readonly string TestnetPassphrase = "Test SDF Network ; September 2015";
 
         public Network(string networkPassphrase)
         {
@@ -21,12 +21,12 @@ namespace stellar_dotnet_sdk
 
         public static Network Public()
         {
-            return new Network(PUBLIC);
+            return new Network(PublicPassphrase);
         }
 
         public static Network Test()
         {
-            return new Network(TESTNET);
+            return new Network(TestnetPassphrase);
         }
 
         public static void Use(Network network)
@@ -36,7 +36,7 @@ namespace stellar_dotnet_sdk
 
         public static bool IsPublicNetwork(Network network)
         {
-            return network.NetworkPassphrase == PUBLIC;
+            return network.NetworkPassphrase == PublicPassphrase;
         }
 
         public static void UsePublicNetwork()

--- a/stellar-dotnet-sdk/requests/FriendBotRequestBuilder.cs
+++ b/stellar-dotnet-sdk/requests/FriendBotRequestBuilder.cs
@@ -18,12 +18,12 @@ namespace stellar_dotnet_sdk.requests
         {
             if (Network.Current == null)
             {
-                throw new NotSupportedException("FriendBot requires the TESTNET Network to be set explicitly.");
+                throw new NotSupportedException("FriendBot requires the Testnet Network to be set explicitly.");
             }
 
             if (Network.IsPublicNetwork(Network.Current))
             {
-                throw new NotSupportedException("FriendBot is only supported on the TESTNET Network.");
+                throw new NotSupportedException("FriendBot is only supported on the Testnet Network.");
             }
         }
 


### PR DESCRIPTION
This is a small change that exposes the public and testnet passphrases to users. It was mentioned in #109

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
