### PR TITLE
Add TimeSpan overloads to TimeBounds ctor

### DIFF
--- a/stellar-dotnet-sdk-test/TimeBoundsTest.cs
+++ b/stellar-dotnet-sdk-test/TimeBoundsTest.cs
@@ -75,5 +75,28 @@ namespace stellar_dotnet_sdk_test
 
             Assert.ThrowsException<ArgumentException>(() => new TimeBounds(now, yesterday));
         }
+
+        [TestMethod]
+        public void TestTimeBoundsWithDuration()
+        {
+            var now = new DateTime(2018, 12, 01, 17, 30, 30);
+            var duration = TimeSpan.FromDays(2.0);
+            var timeBounds = new TimeBounds(now, duration);
+
+            Assert.AreEqual(1543685430, timeBounds.MinTime);
+            Assert.AreEqual(1543858230, timeBounds.MaxTime);
+        }
+
+        [TestMethod]
+        public void TestTimeBoundsWithDurationFromUtcNow()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var duration = TimeSpan.FromDays(2.0);
+            var timeBounds = new TimeBounds(duration);
+            var maxDateTime = DateTimeOffset.FromUnixTimeSeconds(timeBounds.MaxTime);
+
+            Assert.AreNotEqual(0, timeBounds.MinTime);
+            Assert.IsTrue(maxDateTime > now);
+        }
     }
 }

--- a/stellar-dotnet-sdk/TimeBounds.cs
+++ b/stellar-dotnet-sdk/TimeBounds.cs
@@ -54,6 +54,23 @@ namespace stellar_dotnet_sdk
             _maxTime = (ulong) maxEpoch;
         }
 
+        /// <summary>
+        /// Timebounds constructor.
+        /// </summary>
+        /// <param name="minTime">earliest time the transaction is valid from</param>
+        /// <param name="duration">duration window the transaction is valid for</param>
+        public TimeBounds(DateTimeOffset minTime, TimeSpan duration) : this(minTime, minTime.Add(duration))
+        {
+        }
+
+        /// <summary>
+        /// Timebounds constructor.
+        /// </summary>
+        /// <param name="duration">duration window the transaction is valid for from now</param>
+        public TimeBounds(TimeSpan duration) : this(DateTimeOffset.UtcNow, duration)
+        {
+        }
+
         public static TimeBounds FromXdr(xdr.TimeBounds timeBounds)
         {
             if (timeBounds == null)

--- a/stellar-dotnet-sdk/WebAuthentication.cs
+++ b/stellar-dotnet-sdk/WebAuthentication.cs
@@ -46,7 +46,7 @@ namespace stellar_dotnet_sdk
 
             network = network ?? Network.Current;
             var validFrom = now ?? DateTimeOffset.Now;
-            var validTo = validFrom.Add(timeout ?? TimeSpan.FromMinutes(5.0));
+            var validFor = timeout ?? TimeSpan.FromMinutes(5.0);
 
             var sourceAccountKeypair = KeyPair.FromAccountId(clientAccountId);
 
@@ -56,7 +56,7 @@ namespace stellar_dotnet_sdk
             var manageDataKey = $"{anchorName} auth";
             var manageDataValue = Encoding.UTF8.GetBytes(Convert.ToBase64String(nonce));
 
-            var timeBounds = new TimeBounds(validFrom, validTo);
+            var timeBounds = new TimeBounds(validFrom, validFor);
 
             var operation = new ManageDataOperation.Builder(manageDataKey, manageDataValue)
                 .SetSourceAccount(sourceAccountKeypair)


### PR DESCRIPTION
I added two overloads to the `TimeBounds` ctor so that it's easier to build timebounds that are valid from e.g. now.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
