### PR TITLE
Correctly deserialise text memos as ascii

### DIFF
--- a/stellar-dotnet-sdk-test/MemoTest.cs
+++ b/stellar-dotnet-sdk-test/MemoTest.cs
@@ -187,5 +187,24 @@ namespace stellar_dotnet_sdk_test
             Assert.AreEqual(memo.GetHashCode(), memo2.GetHashCode());
             Assert.AreEqual(memo, memo2);
         }
+
+        [TestMethod]
+        public void TestMemoTextAsciiEncodedButTooLongIfUtf8()
+        {
+            // This test comes from transaction 3e88850619eafebb844acd8c672fce55159cbdabbcda4e9e4d6de1e0c3636116
+            // on the test network. If the memo is decoded as UTF8, its length is above the limit of 28, but if
+            // decoded as ASCII (as per spec) it's fine.
+            var txXdr =
+                "AAAAAGqjwSAMOZoob9PCTn1rNxY0qjJyBovxDR912gObtac6AAAAZAAGuwkAAABSAAAAAQAAAAAAAAAAAAAAAF5h4XsAAAABAAAAFDd8q5x7M/nN9XhWt2RxdmpxZmltAAAAAQAAAAAAAAABAAAAAOHq5mmDjeY0Rhr+xQSKjKYMWFD9MgjiE5JxgQrBxthIAAAAAU1PT04AAAAA4ermaYON5jRGGv7FBIqMpgxYUP0yCOITknGBCsHG2EgAAAAAAJiWgAAAAAAAAAABm7WnOgAAAEDO4OJ76sJic/t9tm4Nk1uLxvfD5ZUIZedqBQj2k87nCmMVtJGc96moJdDfe2t/C9Dx8ZsIgD/NHHUXs9hXvXsN";
+            var tx = Transaction.FromEnvelopeXdr(txXdr);
+            if (tx.Memo is MemoText memo)
+            {
+                Assert.AreEqual(20, memo.MemoTextValue.Length);
+            }
+            else
+            {
+                throw new Exception("Memo should be MemoText");
+            }
+        }
     }
 }

--- a/stellar-dotnet-sdk/MemoText.cs
+++ b/stellar-dotnet-sdk/MemoText.cs
@@ -9,8 +9,8 @@ namespace stellar_dotnet_sdk
         public MemoText(string text)
         {
             MemoTextValue = text ?? throw new ArgumentNullException(nameof(text), "text cannot be null");
-
-            var length = Encoding.UTF8.GetBytes(text).Length;
+            // RFC section 4.11 defines strings as ASCII encoded
+            var length = Encoding.ASCII.GetBytes(text).Length;
             if (length > 28)
                 throw new MemoTooLongException("text must be <= 28 bytes. length=" + length);
         }


### PR DESCRIPTION
[This](https://stellar.expert/explorer/testnet/tx/3e88850619eafebb844acd8c672fce55159cbdabbcda4e9e4d6de1e0c3636116) transaction triggered this bug. 

We were deserialising text memos wrong since the text is encoded as ascii and not as utf8. This PR fixes this.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
