### PR TITLE
fix building transaction with muxed account source

### DIFF
--- a/stellar-dotnet-sdk-test/AccountTest.cs
+++ b/stellar-dotnet-sdk-test/AccountTest.cs
@@ -12,7 +12,7 @@ namespace stellar_dotnet_sdk_test
         {
             try
             {
-                var unused = new Account(null, 10L);
+                var unused = new Account((string) null, 10L);
                 Assert.Fail();
             }
             catch (ArgumentNullException)
@@ -28,6 +28,26 @@ namespace stellar_dotnet_sdk_test
             catch (ArgumentNullException)
             {
             }
+        }
+
+        [TestMethod]
+        public void TestWithStringArgumentIsKeyPair()
+        {
+            var keypair = KeyPair.Random();
+            var account = new Account(keypair.Address, 7);
+            Assert.AreEqual(account.AccountId, keypair.AccountId);
+            Assert.AreEqual(account.KeyPair.AccountId, keypair.AccountId);
+        }
+
+        [TestMethod]
+        public void TestWithMuxedAccount()
+        {
+            var keypair = KeyPair.Random();
+            var muxed = new MuxedAccountMed25519(keypair, 10);
+            var account = new Account(muxed, 7);
+            Assert.AreNotEqual(account.AccountId, keypair.AccountId);
+            Assert.AreEqual(account.AccountId, muxed.AccountId);
+            Assert.AreEqual(account.KeyPair.AccountId, keypair.AccountId);
         }
 
         [TestMethod]

--- a/stellar-dotnet-sdk-test/TransactionTest.cs
+++ b/stellar-dotnet-sdk-test/TransactionTest.cs
@@ -422,5 +422,28 @@ namespace stellar_dotnet_sdk_test
                 "AAAAAEdL24Ttos6RnqXCsn8duaV035/QZSC9RXw29IknigHpAAAD6AFb56cAAukDAAAAAQAAAAAAAAAAAAAAAF20fKAAAAACjCiEBz2CpG0AAAABAAAAAAAAAAEAAAAADq+QhtWseqhtnwRIFyZRdLMOVtIqzkujfzUQ22rwZuEAAAAAAAAAAGZeJLcAAAAAAAAAASeKAekAAABAE+X7cGoBhuJ5SDB8WH2B1ZA2RrWIXxGtx+n6wE5d/EggDTpZhRm92b33QqjPUFOfcZ+zbcM+Ny0WR2vcYHEXDA==");
             Assert.AreEqual("GBDUXW4E5WRM5EM6UXBLE7Y5XGSXJX472BSSBPKFPQ3PJCJHRIA6SH4C", tx.SourceAccount.AccountId);
         }
+
+        [TestMethod]
+        public void TestTransactionWithMuxedAccount()
+        {
+            var network = new Network("Standalone Network ; February 2017");
+            var source = KeyPair.FromSecretSeed(network.NetworkId);
+            var txSource = new MuxedAccountMed25519(source, 0);
+            var account = new Account(txSource, 7);
+            var destination = KeyPair.FromAccountId("GDQERENWDDSQZS7R7WKHZI3BSOYMV3FSWR7TFUYFTKQ447PIX6NREOJM");
+            var amount = "2000";
+            var asset = new AssetTypeNative();
+            var tx = new TransactionBuilder(account)
+                .SetFee(100)
+                .AddTimeBounds(new TimeBounds(0, 0))
+                .AddOperation(
+                    new PaymentOperation.Builder(destination, asset, amount).Build())
+                .AddMemo(new MemoText("Happy birthday!"))
+                .Build();
+            var xdr = tx.ToUnsignedEnvelopeXdrBase64(TransactionBase.TransactionXdrVersion.V1);
+            var back = TransactionBuilder.FromEnvelopeXdr(xdr) as Transaction;
+            Assert.IsNotNull(back);
+            Assert.AreEqual(txSource.Address, back.SourceAccount.Address);
+        }
     }
 }

--- a/stellar-dotnet-sdk/Account.cs
+++ b/stellar-dotnet-sdk/Account.cs
@@ -10,23 +10,52 @@ namespace stellar_dotnet_sdk
         ///<summary>
         /// Class constructor.
         /// </summary>
-        /// <param name="keypair">KeyPair associated with this Account</param> 
-        /// <param name="sequenceNumber">Current sequence number of the account (can be obtained using dotnet-stellar-sdk or horizon server)</param> 
+        /// <param name="accountId">KeyPair associated with this Account</param>
+        /// <param name="sequenceNumber">Current sequence number of the account (can be obtained using dotnet-stellar-sdk or horizon server)</param>
         public Account(string accountId, long? sequenceNumber)
         {
-            AccountId = accountId ?? throw new ArgumentNullException(nameof(accountId), "accountId cannot be null");
+            if (accountId is null) throw new ArgumentNullException(nameof(accountId), "accountId cannot be null");
+
+            MuxedAccount = KeyPair.FromAccountId(accountId);
             SequenceNumber = sequenceNumber ?? throw new ArgumentNullException(nameof(sequenceNumber), "sequenceNumber cannot be null");
         }
-        
+
+        ///<summary>
+        /// Class constructor.
+        /// </summary>
+        /// <param name="muxedAccount">KeyPair associated with this Account</param>
+        /// <param name="sequenceNumber">Current sequence number of the account (can be obtained using dotnet-stellar-sdk or horizon server)</param>
+        public Account(IAccountId muxedAccount, long? sequenceNumber)
+        {
+            MuxedAccount = muxedAccount ?? throw new ArgumentNullException(nameof(muxedAccount), "muxedAccount cannot be null");
+            SequenceNumber = sequenceNumber ?? throw new ArgumentNullException(nameof(sequenceNumber), "sequenceNumber cannot be null");
+        }
+
         /// <summary>
         /// Returns the AccountID of the account.
         /// </summary>
-        public string AccountId { get; }
+        public string AccountId => MuxedAccount.AccountId;
 
         /// <summary>
         /// Returns the KeyPair of the account.
         /// </summary>
-        public KeyPair KeyPair => KeyPair.FromAccountId(AccountId);
+        public KeyPair KeyPair
+        {
+            get
+            {
+                switch (MuxedAccount)
+                {
+                    case KeyPair kp:
+                        return kp;
+                    case MuxedAccountMed25519 ma:
+                        return ma.Key;
+                    default:
+                        throw new Exception("Invalid Account MuxedAccount type");
+                }
+            }
+        }
+
+        public IAccountId MuxedAccount { get; }
 
         /// <summary>
         /// The sequence number

--- a/stellar-dotnet-sdk/ITransactionBuilderAccount.cs
+++ b/stellar-dotnet-sdk/ITransactionBuilderAccount.cs
@@ -5,6 +5,7 @@
         string AccountId { get; }
 
         KeyPair KeyPair { get; }
+        IAccountId MuxedAccount { get; }
         long SequenceNumber { get; }
 
         ///<summary>

--- a/stellar-dotnet-sdk/TransactionBase.cs
+++ b/stellar-dotnet-sdk/TransactionBase.cs
@@ -127,9 +127,9 @@ namespace stellar_dotnet_sdk
         ///     Generates TransactionEnvelope XDR object. This transaction MUST be signed before being useful
         /// </summary>
         /// <returns></returns>
-        public string ToUnsignedEnvelopeXdrBase64()
+        public string ToUnsignedEnvelopeXdrBase64(TransactionXdrVersion version = TransactionXdrVersion.V0)
         {
-            var envelope = ToUnsignedEnvelopeXdr();
+            var envelope = ToUnsignedEnvelopeXdr(version);
             var writer = new XdrDataOutputStream();
             TransactionEnvelope.Encode(writer, envelope);
 
@@ -140,9 +140,9 @@ namespace stellar_dotnet_sdk
         ///     Returns base64-encoded TransactionEnvelope XDR object. Transaction need to have at least one signature.
         /// </summary>
         /// <returns></returns>
-        public string ToEnvelopeXdrBase64()
+        public string ToEnvelopeXdrBase64(TransactionXdrVersion version = TransactionXdrVersion.V0)
         {
-            var envelope = ToEnvelopeXdr();
+            var envelope = ToEnvelopeXdr(version);
             var writer = new XdrDataOutputStream();
             TransactionEnvelope.Encode(writer, envelope);
 

--- a/stellar-dotnet-sdk/TransactionBuilder.cs
+++ b/stellar-dotnet-sdk/TransactionBuilder.cs
@@ -126,7 +126,7 @@ namespace stellar_dotnet_sdk
             var totalFee = operations.Length * _fee;
             if (totalFee > UInt32.MaxValue) throw new InvalidOperationException("Transaction fee overflow");
 
-            var transaction = new Transaction(_sourceAccount.KeyPair, (uint) totalFee,
+            var transaction = new Transaction(_sourceAccount.MuxedAccount, (uint) totalFee,
                 _sourceAccount.IncrementedSequenceNumber, operations, _memo, _timeBounds);
             // Increment sequence number when there were no exceptions when creating a transaction
             _sourceAccount.IncrementSequenceNumber();

--- a/stellar-dotnet-sdk/responses/AccountResponse.cs
+++ b/stellar-dotnet-sdk/responses/AccountResponse.cs
@@ -38,7 +38,7 @@ namespace stellar_dotnet_sdk.responses
         [JsonProperty(PropertyName = "thresholds")]
         public Thresholds Thresholds { get; set; }
 
-        [JsonProperty(PropertyName = "flags")] 
+        [JsonProperty(PropertyName = "flags")]
         public Flags Flags { get; set; }
 
         [JsonProperty(PropertyName = "balances")]
@@ -55,6 +55,8 @@ namespace stellar_dotnet_sdk.responses
         public long IncrementedSequenceNumber => SequenceNumber + 1;
 
         public KeyPair KeyPair => KeyPair.FromAccountId(AccountId);
+
+        public IAccountId MuxedAccount => KeyPair;
 
         public void IncrementSequenceNumber()
         {


### PR DESCRIPTION
This PR also includes 9891652693feeb1013c8e63c67f0ad785708ae03, 7321d7abf8818761b9b28038f945e862f900cfb2 and 97ba78e2e02a0fcc94862d3c4746d7c655a3da63. 

Similarly to the js sdk, I added a `TransactionBase` class for `Transaction` and `FeeBumpTransaction`. I renamed the `Transaction.Builder` to `TransactionBuilder` but kept the inner class with a deprecation warning for backward compatibility.
`Account` did not play well with the new `MuxedAccount`, so I added an overload of the ctor to accept `MuxedAccount`. If the user passes a string to the ctor, we assume it's a normal keypair and parse it with `KeyPair.FromAccountId`. That way we are backward compatible with old code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

