### PR TITLE
Fix memo check to support muxed accounts

### DIFF
--- a/stellar-dotnet-sdk-test/ServerCheckMemoRequiredTest.cs
+++ b/stellar-dotnet-sdk-test/ServerCheckMemoRequiredTest.cs
@@ -156,6 +156,32 @@ namespace stellar_dotnet_sdk_test
             await _server.CheckMemoRequired(tx);
         }
 
+        [TestMethod]
+        public async Task TestCheckFeeBumpTransaction()
+        {
+            var accountId = "GAYHAAKPAQLMGIJYMIWPDWCGUCQ5LAWY4Q7Q3IKSP57O7GUPD3NEOSEA";
+            var innerTx = BuildTransaction(accountId, new Operation[] { }, Memo.Text("foobar"));
+            var feeSource = KeyPair.FromAccountId("GD7HCWFO77E76G6BKJLRHRFRLE6I7BMPJQZQKGNYTT3SPE6BA4DHJAQY");
+            var tx = TransactionBuilder.BuildFeeBumpTransaction(feeSource, innerTx, 200);
+            await _server.CheckMemoRequired(tx);
+        }
+
+        [TestMethod]
+        public async Task TestSkipCheckIfDestinationIsMuxedAccount()
+        {
+            var accountId = "GAYHAAKPAQLMGIJYMIWPDWCGUCQ5LAWY4Q7Q3IKSP57O7GUPD3NEOSEA";
+
+            var muxed = MuxedAccountMed25519.FromMuxedAccountId(
+                "MAAAAAAAAAAAJURAAB2X52XFQP6FBXLGT6LWOOWMEXWHEWBDVRZ7V5WH34Y22MPFBHUHY");
+
+            var payment = new PaymentOperation
+                    .Builder(muxed, new AssetTypeNative(), "100.500")
+                .Build();
+
+            var tx = BuildTransaction(accountId, new Operation[] { payment }, Memo.None(), skipDefaultOp: true);
+            await _server.CheckMemoRequired(tx);
+        }
+
         private string BuildAccountResponse(string accountId, Dictionary<string, string> data = null)
         {
             var accountData = data ?? new Dictionary<string, string>();
@@ -184,15 +210,18 @@ namespace stellar_dotnet_sdk_test
             return BuildTransaction(destination, new Operation[] { });
         }
 
-        private Transaction BuildTransaction(string destinationAccountId, Operation[] operations, Memo memo = null)
+        private Transaction BuildTransaction(string destinationAccountId, Operation[] operations, Memo memo = null, bool skipDefaultOp = false)
         {
             var keypair = KeyPair.Random();
             var destination = KeyPair.FromAccountId(destinationAccountId);
             var account = new AccountResponse(destinationAccountId, 56199647068161);
-            var builder = new TransactionBuilder(account)
-                .AddOperation(
+            var builder = new TransactionBuilder(account);
+            if (!skipDefaultOp)
+            {
+                builder.AddOperation(
                     new PaymentOperation.Builder(destination, new AssetTypeNative(), "100.50")
                         .Build());
+            }
 
             if (memo != null)
             {

--- a/stellar-dotnet-sdk/IAccountId.cs
+++ b/stellar-dotnet-sdk/IAccountId.cs
@@ -8,5 +8,6 @@ namespace stellar_dotnet_sdk
         byte[] PublicKey { get; }
         string Address { get; }
         string AccountId { get; }
+        bool IsMuxedAccount { get; }
     }
 }

--- a/stellar-dotnet-sdk/InflationOperation.cs
+++ b/stellar-dotnet-sdk/InflationOperation.cs
@@ -5,7 +5,7 @@ namespace stellar_dotnet_sdk
 {
     /// <summary>
     /// Use <see cref="Builder"/> to create a new InflationOperation.
-    /// 
+    ///
     /// See also: <see href="https://www.stellar.org/developers/guides/concepts/list-of-operations.html#inflation">Inflation</see>
     /// </summary>
     public class InflationOperation : Operation
@@ -22,14 +22,14 @@ namespace stellar_dotnet_sdk
 
         public class Builder
         {
-            private KeyPair mSourceAccount;
+            private IAccountId mSourceAccount;
 
             /// <summary>
             ///     Sets the source account for this operation.
             /// </summary>
             /// <param name="sourceAccount">The operation's source account.</param>
             /// <returns>Builder object so you can chain methods.</returns>
-            public Builder SetSourceAccount(KeyPair sourceAccount)
+            public Builder SetSourceAccount(IAccountId sourceAccount)
             {
                 mSourceAccount = sourceAccount ?? throw new ArgumentNullException(nameof(sourceAccount), "sourceAccount cannot be null");
                 return this;

--- a/stellar-dotnet-sdk/KeyPair.cs
+++ b/stellar-dotnet-sdk/KeyPair.cs
@@ -162,6 +162,8 @@ namespace stellar_dotnet_sdk
             }
         }
 
+        public bool IsMuxedAccount => false;
+
         /// <summary>
         /// Returns a KeyPair from a Public Key
         /// </summary>

--- a/stellar-dotnet-sdk/MuxedAccountMed25519.cs
+++ b/stellar-dotnet-sdk/MuxedAccountMed25519.cs
@@ -73,5 +73,7 @@ namespace stellar_dotnet_sdk
         /// Get the MuxedAccount account id, starting with M.
         /// </summary>
         public string AccountId => Address;
+
+        public bool IsMuxedAccount => true;
     }
 }

--- a/stellar-dotnet-sdk/PathPaymentStrictReceiveOperation.cs
+++ b/stellar-dotnet-sdk/PathPaymentStrictReceiveOperation.cs
@@ -109,7 +109,7 @@ namespace stellar_dotnet_sdk
             /// <param name="destAsset"> The asset the destination account receives.</param>
             /// <param name="destAmount"> The amount of destination asset the destination account receives.</param>
             /// <exception cref="ArithmeticException"> When sendMax or destAmount has more than 7 decimal places.</exception>
-            public Builder(Asset sendAsset, string sendMax, KeyPair destination, Asset destAsset, string destAmount)
+            public Builder(Asset sendAsset, string sendMax, IAccountId destination, Asset destAsset, string destAmount)
             {
                 _SendAsset = sendAsset ?? throw new ArgumentNullException(nameof(sendAsset), "sendAsset cannot be null");
                 _SendMax = sendMax ?? throw new ArgumentNullException(nameof(sendMax), "sendMax cannot be null");
@@ -143,7 +143,7 @@ namespace stellar_dotnet_sdk
             /// </summary>
             /// <param name="sourceAccount"> The operation's source account.</param>
             /// <returns>Builder object so you can chain methods.</returns>
-            public Builder SetSourceAccount(KeyPair sourceAccount)
+            public Builder SetSourceAccount(IAccountId sourceAccount)
             {
                 _SourceAccount = sourceAccount ?? throw new ArgumentNullException(nameof(sourceAccount), "sourceAccount cannot be null");
                 return this;

--- a/stellar-dotnet-sdk/PathPaymentStrictSendOperation.cs
+++ b/stellar-dotnet-sdk/PathPaymentStrictSendOperation.cs
@@ -110,7 +110,7 @@ namespace stellar_dotnet_sdk
             /// <param name="destAsset"> The asset the destination account receives.</param>
             /// <param name="destMin"> The amount of destination asset the destination account receives.</param>
             /// <exception cref="ArithmeticException"> When sendAmount or destMin has more than 7 decimal places.</exception>
-            public Builder(Asset sendAsset, string sendAmount, KeyPair destination, Asset destAsset, string destMin)
+            public Builder(Asset sendAsset, string sendAmount, IAccountId destination, Asset destAsset, string destMin)
             {
                 _SendAsset = sendAsset ?? throw new ArgumentNullException(nameof(sendAsset), "sendAsset cannot be null");
                 _SendAmount = sendAmount ?? throw new ArgumentNullException(nameof(sendAmount), "sendAmount cannot be null");
@@ -144,7 +144,7 @@ namespace stellar_dotnet_sdk
             /// </summary>
             /// <param name="sourceAccount"> The operation's source account.</param>
             /// <returns>Builder object so you can chain methods.</returns>
-            public Builder SetSourceAccount(KeyPair sourceAccount)
+            public Builder SetSourceAccount(IAccountId sourceAccount)
             {
                 _SourceAccount = sourceAccount ?? throw new ArgumentNullException(nameof(sourceAccount), "sourceAccount cannot be null");
                 return this;

--- a/stellar-dotnet-sdk/PaymentOperation.cs
+++ b/stellar-dotnet-sdk/PaymentOperation.cs
@@ -56,14 +56,15 @@ namespace stellar_dotnet_sdk
         ///<summary>
         /// Builds Payment operation.
         ///</summary>
-        ///<see cref="PathPaymentOperation"/>
+        ///<see cref="PathPaymentStrictReceiveOperation"/>
+        /// ///<see cref="PathPaymentStrictSendOperation"/>
         public class Builder
         {
-            private readonly string amount;
-            private readonly Asset asset;
-            private readonly IAccountId destination;
+            private readonly string _amount;
+            private readonly Asset _asset;
+            private readonly IAccountId _destination;
 
-            private IAccountId mSourceAccount;
+            private IAccountId _sourceAccount;
 
             ///<summary>
             /// Construct a new PaymentOperation builder from a PaymentOp XDR.
@@ -71,9 +72,9 @@ namespace stellar_dotnet_sdk
             ///<param name="op"><see cref="PaymentOp"/></param>
             public Builder(PaymentOp op)
             {
-                destination = MuxedAccount.FromXdrMuxedAccount(op.Destination);
-                asset = Asset.FromXdr(op.Asset);
-                amount = FromXdrAmount(op.Amount.InnerValue);
+                _destination = MuxedAccount.FromXdrMuxedAccount(op.Destination);
+                _asset = Asset.FromXdr(op.Asset);
+                _amount = FromXdrAmount(op.Amount.InnerValue);
             }
 
             ///<summary>
@@ -82,11 +83,11 @@ namespace stellar_dotnet_sdk
             ///<param name="destination">The destination keypair (uses only the public key).</param>
             ///<param name="asset">The asset to send.</param>
             ///<param name="amount">The amount to send in lumens.</param>
-            public Builder(KeyPair destination, Asset asset, string amount)
+            public Builder(IAccountId destination, Asset asset, string amount)
             {
-                this.destination = destination;
-                this.asset = asset;
-                this.amount = amount;
+                _destination = destination;
+                _asset = asset;
+                _amount = amount;
             }
 
             ///<summary>
@@ -95,9 +96,9 @@ namespace stellar_dotnet_sdk
             ///<param name="account">The operation's source account.</param>
             ///<returns>Builder object so you can chain methods.</returns>
             ///
-            public Builder SetSourceAccount(KeyPair account)
+            public Builder SetSourceAccount(IAccountId account)
             {
-                mSourceAccount = account;
+                _sourceAccount = account;
                 return this;
             }
 
@@ -106,9 +107,9 @@ namespace stellar_dotnet_sdk
             ///</summary>
             public PaymentOperation Build()
             {
-                var operation = new PaymentOperation(destination, asset, amount);
-                if (mSourceAccount != null)
-                    operation.SourceAccount = mSourceAccount;
+                var operation = new PaymentOperation(_destination, _asset, _amount);
+                if (_sourceAccount != null)
+                    operation.SourceAccount = _sourceAccount;
                 return operation;
             }
         }


### PR DESCRIPTION
If the destination of a payment is a muxed account we do not need to check for the memo.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
