### PR TITLE
fix: don't parse claim predicate datetime

### DIFF
--- a/stellar-dotnet-sdk-test/ClaimPredicateTest.cs
+++ b/stellar-dotnet-sdk-test/ClaimPredicateTest.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using stellar_dotnet_sdk;
 
@@ -15,6 +16,16 @@ namespace stellar_dotnet_sdk_test
             var parsed = (ClaimPredicateBeforeAbsoluteTime) ClaimPredicate.FromXdr(xdr);
 
             Assert.AreEqual(1600720493, parsed.DateTime.ToUnixTimeSeconds());
+        }
+        [TestMethod]
+        public void TestClaimPredicateBeforeAbsoluteTimeMaxInt()
+        {
+            var predicate = ClaimPredicate.BeforeAbsoluteTime(Int64.MaxValue);
+            var xdr = predicate.ToXdr();
+
+            var parsed = (ClaimPredicateBeforeAbsoluteTime) ClaimPredicate.FromXdr(xdr);
+
+            Assert.AreEqual(Int64.MaxValue, parsed.UnixTimeSeconds);
         }
 
         [TestMethod]

--- a/stellar-dotnet-sdk-test/responses/OperationDeserializerTest.cs
+++ b/stellar-dotnet-sdk-test/responses/OperationDeserializerTest.cs
@@ -637,6 +637,17 @@ namespace stellar_dotnet_sdk_test.responses
 
             AssertCreateClaimableBalanceData(back);
         }
+        
+        [TestMethod]
+        public void TestSerializationCreateClaimableBalanceAbsBeforeMaxIntOperation()
+        {
+            var json = File.ReadAllText(Path.Combine("testdata/operations", "operationClaimableBalanceAbsBeforeMaxInt.json"));
+            var instance = JsonSingleton.GetInstance<OperationResponse>(json);
+            Assert.IsTrue(instance is CreateClaimableBalanceOperationResponse);
+            var operation = (CreateClaimableBalanceOperationResponse)instance;
+
+            Assert.IsNotNull(operation.Claimants[0].Predicate.AbsBefore);
+        }
 
         private static void AssertCreateClaimableBalanceData(OperationResponse instance)
         {
@@ -665,7 +676,7 @@ namespace stellar_dotnet_sdk_test.responses
 
             AssertClaimClaimableBalanceData(back);
         }
-
+        
         private static void AssertClaimClaimableBalanceData(OperationResponse instance)
         {
             Assert.IsTrue(instance is ClaimClaimableBalanceOperationResponse);

--- a/stellar-dotnet-sdk-test/stellar-dotnet-sdk-test.csproj
+++ b/stellar-dotnet-sdk-test/stellar-dotnet-sdk-test.csproj
@@ -362,5 +362,8 @@
     <None Update="testdata\claimableBalance.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="testdata\operations\operationClaimableBalanceAbsBeforeMaxInt.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/stellar-dotnet-sdk-test/testdata/operations/operationClaimableBalanceAbsBeforeMaxInt.json
+++ b/stellar-dotnet-sdk-test/testdata/operations/operationClaimableBalanceAbsBeforeMaxInt.json
@@ -1,0 +1,38 @@
+{
+  "_links": {
+    "self": {
+      "href": "https://horizon-testnet.stellar.org/operations/602248904196097"
+    },
+    "transaction": {
+      "href": "https://horizon-testnet.stellar.org/transactions/9c84de3a0cc6d3a2a16fb59b0c02c2b78cfa41c0aeb54b05c356fdb6b3652425"
+    },
+    "effects": {
+      "href": "https://horizon-testnet.stellar.org/operations/602248904196097/effects"
+    },
+    "succeeds": {
+      "href": "https://horizon-testnet.stellar.org/effects?order=desc\u0026cursor=602248904196097"
+    },
+    "precedes": {
+      "href": "https://horizon-testnet.stellar.org/effects?order=asc\u0026cursor=602248904196097"
+    }
+  },
+  "id": "602248904196097",
+  "paging_token": "602248904196097",
+  "transaction_successful": true,
+  "source_account": "GDREETGGEEUYMPPHATCUFO5VU7EA4AT7KY45BO2DKROOOGDXHY2IRDN5",
+  "type": "create_claimable_balance",
+  "type_i": 14,
+  "created_at": "2020-11-05T22:15:06Z",
+  "transaction_hash": "9c84de3a0cc6d3a2a16fb59b0c02c2b78cfa41c0aeb54b05c356fdb6b3652425",
+  "sponsor": "GDREETGGEEUYMPPHATCUFO5VU7EA4AT7KY45BO2DKROOOGDXHY2IRDN5",
+  "asset": "native",
+  "amount": "5.0000000",
+  "claimants": [
+    {
+      "destination": "GDREETGGEEUYMPPHATCUFO5VU7EA4AT7KY45BO2DKROOOGDXHY2IRDN5",
+      "predicate": {
+        "abs_before": "+131971-04-21T00:00:00Z"
+      }
+    }
+  ]
+}

--- a/stellar-dotnet-sdk/ClaimPredicate.cs
+++ b/stellar-dotnet-sdk/ClaimPredicate.cs
@@ -19,7 +19,7 @@ namespace stellar_dotnet_sdk
         public static ClaimPredicate Unconditional() => new ClaimPredicateUnconditional();
         
         public static ClaimPredicate BeforeAbsoluteTime(long unixTimestamp) =>
-            BeforeAbsoluteTime(DateTimeOffset.FromUnixTimeSeconds(unixTimestamp));
+            new ClaimPredicateBeforeAbsoluteTime(unixTimestamp);
         
         public static ClaimPredicate BeforeAbsoluteTime(DateTimeOffset dateTime) => new ClaimPredicateBeforeAbsoluteTime(dateTime);
 

--- a/stellar-dotnet-sdk/ClaimPredicateBeforeAbsoluteTime.cs
+++ b/stellar-dotnet-sdk/ClaimPredicateBeforeAbsoluteTime.cs
@@ -4,11 +4,17 @@ namespace stellar_dotnet_sdk
 {
     public class ClaimPredicateBeforeAbsoluteTime : ClaimPredicate
     {
-        public DateTimeOffset DateTime { get; }
+        public DateTimeOffset DateTime { get => DateTimeOffset.FromUnixTimeSeconds(UnixTimeSeconds); }
+        public long UnixTimeSeconds { get; }
 
         public ClaimPredicateBeforeAbsoluteTime(DateTimeOffset dateTime)
         {
-            DateTime = dateTime;
+            UnixTimeSeconds = dateTime.ToUnixTimeSeconds();
+        }
+
+        public ClaimPredicateBeforeAbsoluteTime(long unixTimeSeconds)
+        {
+            UnixTimeSeconds = unixTimeSeconds;
         }
 
         public override xdr.ClaimPredicate ToXdr()
@@ -19,7 +25,7 @@ namespace stellar_dotnet_sdk
                 {
                     InnerValue = xdr.ClaimPredicateType.ClaimPredicateTypeEnum.CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME
                 },
-                AbsBefore = new xdr.Int64(DateTime.ToUnixTimeSeconds()),
+                AbsBefore = new xdr.Int64(UnixTimeSeconds),
             };
         }
     }

--- a/stellar-dotnet-sdk/responses/Predicate.cs
+++ b/stellar-dotnet-sdk/responses/Predicate.cs
@@ -18,7 +18,7 @@ namespace stellar_dotnet_sdk.responses
         public bool Unconditional { get; set; }
         
         [JsonProperty(PropertyName = "abs_before")]
-        public DateTimeOffset? AbsBefore { get; set; }
+        public string AbsBefore { get; set; }
         
         [JsonProperty(PropertyName = "rel_before")]
         public long? RelBefore { get; set; }
@@ -52,7 +52,8 @@ namespace stellar_dotnet_sdk.responses
 
             if (AbsBefore != null)
             {
-                return ClaimPredicate.BeforeAbsoluteTime(AbsBefore.Value);
+                var dateTime = DateTimeOffset.Parse(AbsBefore);
+                return ClaimPredicate.BeforeAbsoluteTime(dateTime);
             }
 
             if (RelBefore != null)


### PR DESCRIPTION
This is the fix for #284 that we discussed. Since there is no way to represent an Iso8601 date in .NET, we simply don't parse the long/string values. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
