### PR TITLE
Support passing in a string for balance id

### DIFF
--- a/stellar-dotnet-sdk-test/OperationTest.cs
+++ b/stellar-dotnet-sdk-test/OperationTest.cs
@@ -890,6 +890,7 @@ namespace stellar_dotnet_sdk_test
             // GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3
             var source = KeyPair.FromSecretSeed("SBPQUZ6G4FZNWFHKUWC5BEYWF6R52E3SEP7R3GWYSM2XTKGF5LNTWW4R");
             
+            // Prepend type bytes (first four bytes are the balance id type)
             var balanceId = Enumerable.Repeat((byte)0x07, 32).Prepend((byte)0).Prepend((byte)0).Prepend((byte)0).Prepend((byte)0).ToArray();
             var operation = new ClaimClaimableBalanceOperation.Builder(balanceId)
                 .SetSourceAccount(source)


### PR DESCRIPTION
Fixes #293 with:

* Adds support for full 36 bytes of balance id (4 bytes type followed by 32 bytes for the body)
  * Keeps support of 32 bytes to keep it as a non-breaking change
* Allows for balance id to be passed in as a string

The tests I've added match the expected behaviour of the tests from the Java SDK which cover the same functionality: https://github.com/stellar/java-stellar-sdk/blob/32331b3a5a4cf62eb6820b5e975032b9ab13887c/src/test/java/org/stellar/sdk/OperationTest.java#L757

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

