### PR TITLE
Check for success while calling SubmitTransaction

### DIFF
--- a/stellar-dotnet-sdk-test/ServerTest.cs
+++ b/stellar-dotnet-sdk-test/ServerTest.cs
@@ -172,7 +172,7 @@ namespace stellar_dotnet_sdk_test
             When().Returns(ResponseMessage(HttpOk, json));
 
             var response = await _server.SubmitTransaction(
-                BuildTransaction().ToEnvelopeXdrBase64(), new SubmitTransactionOptions { SkipMemoRequiredCheck = false });
+                BuildTransaction().ToEnvelopeXdrBase64(), new SubmitTransactionOptions { EnsureSuccess = true });
             Assert.IsTrue(response.IsSuccess());
             Assert.AreEqual(response.Ledger, (uint)826150);
             Assert.AreEqual(response.Hash, "2634d2cf5adcbd3487d1df042166eef53830115844fdde1588828667bf93ff42");

--- a/stellar-dotnet-sdk/Server.cs
+++ b/stellar-dotnet-sdk/Server.cs
@@ -1,4 +1,5 @@
-﻿using stellar_dotnet_sdk.requests;
+﻿using stellar_dotnet_sdk.federation;
+using stellar_dotnet_sdk.requests;
 using stellar_dotnet_sdk.responses;
 using System;
 using System.Collections.Generic;
@@ -170,6 +171,18 @@ namespace stellar_dotnet_sdk
             };
 
             var response = await _httpClient.PostAsync(transactionUri, new FormUrlEncodedContent(paramsPairs.ToArray()));
+
+            if (options.EnsureSuccess && !response.IsSuccessStatusCode)
+            {
+                string responseString = string.Empty;
+                if(response.Content != null)
+                {
+                    responseString = await response.Content.ReadAsStringAsync();
+                }
+                
+                throw new ConnectionErrorException( $"Status code ({response.StatusCode}) is not success.{ ( !string.IsNullOrEmpty(responseString) ? " Content: " + responseString : "") }");
+            }
+            
             if (response.Content != null)
             {
                 var responseString = await response.Content.ReadAsStringAsync();

--- a/stellar-dotnet-sdk/SubmitTransactionOptions.cs
+++ b/stellar-dotnet-sdk/SubmitTransactionOptions.cs
@@ -4,5 +4,6 @@
     {
         public bool SkipMemoRequiredCheck { get; set; }
         public bool FeeBumpTransaction { get; set; }
+        public bool EnsureSuccess { get; set; }
     }
 }


### PR DESCRIPTION
Fixes #296 

- Added `EnsureSuccess` to `SubmitTransactionOptions`
If set to `true`, response of `POST /transactions` will be checked if its status code is success or not

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
