### PR TITLE
Equatable KeyPair

### DIFF
--- a/stellar-dotnet-sdk-test/ClaimPredicateTest.cs
+++ b/stellar-dotnet-sdk-test/ClaimPredicateTest.cs
@@ -17,6 +17,7 @@ namespace stellar_dotnet_sdk_test
 
             Assert.AreEqual(1600720493, parsed.DateTime.ToUnixTimeSeconds());
         }
+        
         [TestMethod]
         public void TestClaimPredicateBeforeAbsoluteTimeMaxInt()
         {

--- a/stellar-dotnet-sdk-test/ClaimPredicateTest.cs
+++ b/stellar-dotnet-sdk-test/ClaimPredicateTest.cs
@@ -17,7 +17,7 @@ namespace stellar_dotnet_sdk_test
 
             Assert.AreEqual(1600720493, parsed.DateTime.ToUnixTimeSeconds());
         }
-        
+
         [TestMethod]
         public void TestClaimPredicateBeforeAbsoluteTimeMaxInt()
         {

--- a/stellar-dotnet-sdk-test/KeyPairTest.cs
+++ b/stellar-dotnet-sdk-test/KeyPairTest.cs
@@ -98,5 +98,39 @@ namespace stellar_dotnet_sdk_test
                 throw;
             }
         }
+
+        [TestMethod]
+        public void TestEqualityWithNullIsFalse()
+        {
+            var keyPair = KeyPair.FromAccountId("GDEAOZWTVHQZGGJY6KG4NAGJQ6DXATXAJO3AMW7C4IXLKMPWWB4FDNFZ");
+            Assert.IsFalse(keyPair.Equals(null));
+        }
+
+        [TestMethod]
+        public void TestEqualityWithKeyWithSecretKeyAndWithout()
+        {
+            var keyPair = KeyPair.FromSecretSeed("SDJHRQF4GCMIIKAAAQ6IHY42X73FQFLHUULAPSKKD4DFDM7UXWWCRHBE");
+            var otherKeyPair = KeyPair.FromAccountId(keyPair.AccountId);
+            Assert.IsFalse(keyPair.Equals(otherKeyPair));
+            Assert.IsFalse(otherKeyPair.Equals(keyPair));
+        }
+
+        [TestMethod]
+        public void TestEqualityWithKeyWithSecretKey()
+        {
+            var keyPair = KeyPair.FromSecretSeed("SDJHRQF4GCMIIKAAAQ6IHY42X73FQFLHUULAPSKKD4DFDM7UXWWCRHBE");
+            var otherKeyPair = KeyPair.FromSecretSeed(keyPair.SecretSeed);
+            Assert.IsTrue(keyPair.Equals(otherKeyPair));
+            Assert.IsTrue(otherKeyPair.Equals(keyPair));
+        }
+
+        [TestMethod]
+        public void TestEqualityWithOnlyPublicKey()
+        {
+            var keyPair = KeyPair.FromAccountId("GDEAOZWTVHQZGGJY6KG4NAGJQ6DXATXAJO3AMW7C4IXLKMPWWB4FDNFZ");
+            var otherKeyPair = KeyPair.FromAccountId(keyPair.AccountId);
+
+            Assert.IsTrue(keyPair.Equals(otherKeyPair));
+        }
     }
 }

--- a/stellar-dotnet-sdk/KeyPair.cs
+++ b/stellar-dotnet-sdk/KeyPair.cs
@@ -12,7 +12,7 @@ namespace stellar_dotnet_sdk
     /// <see cref="KeyPair"/> represents public (and secret) keys of the account.
     /// Currently <see cref="KeyPair"/> only supports ed25519 but in a future this class can be abstraction layer for other public-key signature systems.
     /// </summary>
-    public class KeyPair : IAccountId
+    public class KeyPair : IAccountId, IEquatable<KeyPair>
     {
         private KeyPair(Key secretKey, byte[] seed)
         {
@@ -337,6 +337,14 @@ namespace stellar_dotnet_sdk
         public bool Verify(byte[] data, xdr.Signature signature)
         {
             return Verify(data, signature.InnerValue);
+        }
+
+        public bool Equals(KeyPair other)
+        {
+            if (other == null) return false;
+            if (SeedBytes != null && other.SeedBytes == null) return false;
+            if (SeedBytes == null && other.SeedBytes != null) return false;
+            return _publicKey.Equals(other._publicKey);
         }
     }
 }


### PR DESCRIPTION
This is a fix to #309, note that I implemented `IEquatable<T>` because I think it makes more sense than implementing `IComparable<T>`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
