### PR TITLE
Support ServerUri with a path included

### DIFF
--- a/stellar-dotnet-sdk-test/requests/AccountsRequestBuilderTest.cs
+++ b/stellar-dotnet-sdk-test/requests/AccountsRequestBuilderTest.cs
@@ -26,6 +26,21 @@ namespace stellar_dotnet_sdk_test.requests
         }
 
         [TestMethod]
+        public void TestAccountsBuildUriPathPrefix()
+        {
+            using (var server = new Server("https://nodeapi.com/xlm/authkey/"))
+            {
+                var uri = server.Accounts
+                    .Cursor("13537736921089")
+                    .Limit(200)
+                    .Order(OrderDirection.ASC)
+                    .BuildUri();
+
+                Assert.AreEqual("https://nodeapi.com/xlm/authkey/accounts?cursor=13537736921089&limit=200&order=asc", uri.ToString());
+            }
+        }
+
+        [TestMethod]
         public async Task TestAccountsAccount()
         {
             var jsonResponse = File.ReadAllText(Path.Combine("testdata", "account.json"));

--- a/stellar-dotnet-sdk/requests/RequestBuilder.cs
+++ b/stellar-dotnet-sdk/requests/RequestBuilder.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
-using stellar_dotnet_sdk.responses.operations;
 
 namespace stellar_dotnet_sdk.requests
 {
@@ -20,6 +19,7 @@ namespace stellar_dotnet_sdk.requests
         private readonly List<string> _segments;
         private bool _segmentsAdded;
         protected UriBuilder UriBuilder;
+        private readonly string _serverPathPrefix;
 
         public static HttpClient HttpClient { get; set; }
 
@@ -40,6 +40,9 @@ namespace stellar_dotnet_sdk.requests
         {
             UriBuilder = new UriBuilder(serverUri);
             _segments = new List<string>();
+
+            // Store the required path part of the serverUri
+            _serverPathPrefix = UriBuilder.Path;
 
             if (!string.IsNullOrEmpty(defaultSegment))
                 SetSegments(defaultSegment);
@@ -120,10 +123,10 @@ namespace stellar_dotnet_sdk.requests
         {
             if (_segments.Count > 0)
             {
-                var path = "";
+                var path = _serverPathPrefix;
 
                 foreach (var segment in _segments)
-                    path += "/" + segment;
+                    path += (path.EndsWith("/") ? string.Empty : "/") + segment;
 
                 UriBuilder.Path = path;
 


### PR DESCRIPTION
We are having issues using a Node API provider that requires a path prefix like (`https://provider.com/rpc/xlm/{auth-key}/`).
Currently the SDK only uses the domain part of the supplied Horizon URI, and the path is fully replaced by the segments generated by the various RequestBuilders.

Through this change the original path is now stored and used later on when adding the segments again.

I'm not entirely sure in what category this falls (bug/ feature/ breaking).
If users have set-up the serverUri with a path that shouldn't be there, it would be included now.
I'm happy to update the version once it's clear if it's major/minor/fix.

## Workaround
As a temporary workaround we're using the following:

```fsharp
let prefixUriBuilderOfSnd (first: string) (second: Uri) =
    let urlBuilder = new UriBuilder(first)
    let target = new UriBuilder(second)

    // do not update if the path is the default `/`
    if urlBuilder.Path = "/" then
        target.Uri
    elif target.Path.StartsWith("/") then
        target.Path <- urlBuilder.Path + target.Path[1..]
        target.Uri
    else
        target.Path <- urlBuilder.Path + target.Path
        target.Uri

let private overrideServerUriHandler =
    { new DelegatingHandler(InnerHandler = new HttpClientHandler()) with
        member x.Send(request, cancellationToken) =
            request.RequestUri <- prefixUriBuilderOfSnd serverUri request.RequestUri
            base.Send(request, cancellationToken)
        member x.SendAsync(request, cancellationToken) =
            request.RequestUri <- prefixUriBuilderOfSnd serverUri request.RequestUri
            base.SendAsync(request, cancellationToken)
    }
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
