### PR TITLE
Alphanumeric assets are more specifically typed.

### DIFF
--- a/stellar-dotnet-sdk-test/requests/PathStrictReceiveRequestBuilderTest.cs
+++ b/stellar-dotnet-sdk-test/requests/PathStrictReceiveRequestBuilderTest.cs
@@ -20,7 +20,7 @@ namespace stellar_dotnet_sdk_test.requests
                 // Technically not a valid request since it contains both a source account and assets
                 var req = server.PathStrictReceive
                     .SourceAccount("GARSFJNXJIHO6ULUBK3DBYKVSIZE7SC72S5DYBCHU7DKL22UXKVD7MXP")
-                    .SourceAssets(new[] { new AssetTypeNative(), destinationAsset })
+                    .SourceAssets(new Asset[] { new AssetTypeNative(), destinationAsset })
                     .DestinationAccount("GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V")
                     .DestinationAsset(destinationAsset)
                     .DestinationAmount("10.1");

--- a/stellar-dotnet-sdk-test/requests/PathStrictSendRequestBuilderTest.cs
+++ b/stellar-dotnet-sdk-test/requests/PathStrictSendRequestBuilderTest.cs
@@ -22,7 +22,7 @@ namespace stellar_dotnet_sdk_test.requests
                     .SourceAmount("10.1")
                     .SourceAsset(sourceAsset)
                     .DestinationAccount("GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V")
-                    .DestinationAssets(new[] { new AssetTypeNative(), sourceAsset });
+                    .DestinationAssets(new Asset[] { new AssetTypeNative(), sourceAsset });
 
                 Assert.AreEqual("https://horizon-testnet.stellar.org/paths/strict-send?" +
                                 "source_amount=10.1&" +
@@ -49,7 +49,7 @@ namespace stellar_dotnet_sdk_test.requests
                 var assets = await server.PathStrictSend
                     .SourceAmount("10.1")
                     .SourceAsset(sourceAsset)
-                    .DestinationAssets(new[] { new AssetTypeNative(), sourceAsset })
+                    .DestinationAssets(new Asset[] { new AssetTypeNative(), sourceAsset })
                     .Execute();
 
                 PathsPageDeserializerTest.AssertTestData(assets);

--- a/stellar-dotnet-sdk-test/responses/operations/PathPaymentStrictReceiveOperationResponseTest.cs
+++ b/stellar-dotnet-sdk-test/responses/operations/PathPaymentStrictReceiveOperationResponseTest.cs
@@ -55,8 +55,8 @@ namespace stellar_dotnet_sdk_test.responses.operations
             Assert.AreEqual(operation.Amount, operationTest.Amount);
             Assert.AreEqual(operation.SourceMax, operationTest.SourceMax);
             Assert.AreEqual(operation.SourceAmount, operationTest.SourceAmount);
-            Assert.AreEqual(operation.DestinationAsset, Asset.CreateNonNativeAsset(operationTest.AssetType, operation.AssetIssuer, operationTest.AssetCode));
-            Assert.AreEqual(operation.SourceAsset, Asset.CreateNonNativeAsset(operationTest.SourceAssetType, operation.SourceAssetIssuer, operationTest.SourceAssetCode));
+            Assert.AreEqual(operation.DestinationAsset, Asset.CreateNonNativeAsset(operationTest.AssetCode, operation.AssetIssuer));
+            Assert.AreEqual(operation.SourceAsset, Asset.CreateNonNativeAsset(operationTest.SourceAssetCode, operation.SourceAssetIssuer));
         }
     }
 }

--- a/stellar-dotnet-sdk-test/responses/operations/PathPaymentStrictSendOperationResponseTest.cs
+++ b/stellar-dotnet-sdk-test/responses/operations/PathPaymentStrictSendOperationResponseTest.cs
@@ -55,7 +55,7 @@ namespace stellar_dotnet_sdk_test.responses.operations
             Assert.AreEqual(operation.SourceAmount, operationTest.SourceAmount);
             Assert.AreEqual(operation.DestinationMin, operationTest.DestinationMin);
             Assert.AreEqual(operation.DestinationAsset, Asset.Create(operationTest.AssetType, "", ""));
-            Assert.AreEqual(operation.SourceAsset, Asset.CreateNonNativeAsset(operationTest.SourceAssetType, operationTest.SourceAssetIssuer, operationTest.SourceAssetCode));
+            Assert.AreEqual(operation.SourceAsset, Asset.CreateNonNativeAsset(operationTest.SourceAssetCode, operationTest.SourceAssetIssuer));
         }
     }
 }

--- a/stellar-dotnet-sdk/Asset.cs
+++ b/stellar-dotnet-sdk/Asset.cs
@@ -48,7 +48,7 @@ namespace stellar_dotnet_sdk
         /// </summary>
         /// <param name="code">Asset code</param>
         /// <param name="issuer">Asset issuer</param>
-        public static Asset CreateNonNativeAsset(string code, string issuer)
+        public static AssetTypeCreditAlphaNum CreateNonNativeAsset(string code, string issuer)
         {
             if (code.Length >= 1 && code.Length <= 4)
                 return new AssetTypeCreditAlphaNum4(code, issuer);
@@ -95,17 +95,6 @@ namespace stellar_dotnet_sdk
         /// Generates XDR object from a given Asset object
         ///</summary>
         public abstract xdr.Asset ToXdr();
-
-        ///<summary>
-        /// Creates one of AssetTypeCreditAlphaNum4 or AssetTypeCreditAlphaNum12 object based on a code length
-        /// </summary>
-        public static Asset CreateNonNativeAsset(string assetType, string accountId, string code)
-        {
-            if (assetType == "native")
-                return new AssetTypeNative();
-
-            return CreateNonNativeAsset(code, accountId);
-        }
 
         /// <summary>
         /// Returns the asset canonical name.

--- a/stellar-dotnet-sdk/responses/PathResponse.cs
+++ b/stellar-dotnet-sdk/responses/PathResponse.cs
@@ -35,8 +35,8 @@ namespace stellar_dotnet_sdk.responses
         [JsonProperty(PropertyName = "_links")]
         public PathResponseLinks Links { get; private set; }
 
-        public Asset DestinationAsset => Asset.CreateNonNativeAsset(DestinationAssetType, DestinationAssetIssuer, DestinationAssetCode);
-        public Asset SourceAsset => Asset.CreateNonNativeAsset(SourceAssetType, SourceAssetIssuer, SourceAssetCode);
+        public AssetTypeCreditAlphaNum DestinationAsset => Asset.CreateNonNativeAsset(DestinationAssetCode, DestinationAssetIssuer);
+        public AssetTypeCreditAlphaNum SourceAsset => Asset.CreateNonNativeAsset(SourceAssetCode, SourceAssetIssuer);
 
         public PathResponse()
         {

--- a/stellar-dotnet-sdk/responses/effects/AccountCreditedEffectResponse.cs
+++ b/stellar-dotnet-sdk/responses/effects/AccountCreditedEffectResponse.cs
@@ -38,6 +38,6 @@ namespace stellar_dotnet_sdk.responses.effects
         [JsonProperty(PropertyName = "asset_issuer")]
         public string AssetIssuer { get; private set; }
 
-        public Asset Asset => Asset.CreateNonNativeAsset(AssetType, AssetIssuer, AssetCode);
+        public Asset Asset => Asset.Create(AssetType, AssetCode, AssetIssuer);
     }
 }

--- a/stellar-dotnet-sdk/responses/effects/AccountDebitedEffectResponse.cs
+++ b/stellar-dotnet-sdk/responses/effects/AccountDebitedEffectResponse.cs
@@ -38,6 +38,6 @@ namespace stellar_dotnet_sdk.responses.effects
         [JsonProperty(PropertyName = "asset_issuer")]
         public string AssetIssuer { get; private set; }
 
-        public Asset Asset => Asset.CreateNonNativeAsset(AssetType, AssetIssuer, AssetCode);
+        public Asset Asset => Asset.Create(AssetType, AssetCode, AssetIssuer);
     }
 }

--- a/stellar-dotnet-sdk/responses/effects/TradeEffectResponse.cs
+++ b/stellar-dotnet-sdk/responses/effects/TradeEffectResponse.cs
@@ -69,8 +69,8 @@ namespace stellar_dotnet_sdk.responses.effects
         [JsonProperty(PropertyName = "bought_asset_issuer")]
         public string BoughtAssetIssuer { get; private set; }
 
-        public Asset BoughtAsset => Asset.CreateNonNativeAsset(BoughtAssetType, BoughtAssetIssuer, BoughtAssetCode);
+        public AssetTypeCreditAlphaNum BoughtAsset => Asset.CreateNonNativeAsset(BoughtAssetCode, BoughtAssetIssuer);
 
-        public Asset SoldAsset => Asset.CreateNonNativeAsset(SoldAssetType, SoldAssetIssuer, SoldAssetCode);
+        public AssetTypeCreditAlphaNum SoldAsset => Asset.CreateNonNativeAsset(SoldAssetCode, SoldAssetIssuer);
     }
 }

--- a/stellar-dotnet-sdk/responses/effects/TrustlineCUDResponse.cs
+++ b/stellar-dotnet-sdk/responses/effects/TrustlineCUDResponse.cs
@@ -29,6 +29,6 @@ namespace stellar_dotnet_sdk.responses.effects
         [JsonProperty(PropertyName = "asset_issuer")]
         public string AssetIssuer { get; private set; }
 
-        public Asset Asset => Asset.CreateNonNativeAsset(AssetType, AssetIssuer, AssetCode);
+        public AssetTypeCreditAlphaNum Asset => stellar_dotnet_sdk.Asset.CreateNonNativeAsset(AssetCode, AssetIssuer);
     }
 }

--- a/stellar-dotnet-sdk/responses/operations/AllowTrustOperationResponse.cs
+++ b/stellar-dotnet-sdk/responses/operations/AllowTrustOperationResponse.cs
@@ -88,6 +88,6 @@ namespace stellar_dotnet_sdk.responses.operations
         /// <summary>
         /// The asset to allow trust.
         /// </summary>
-        public Asset Asset => Asset.CreateNonNativeAsset(AssetType, AssetIssuer, AssetCode);
+        public AssetTypeCreditAlphaNum Asset => stellar_dotnet_sdk.Asset.CreateNonNativeAsset(AssetCode, AssetIssuer);
     }
 }

--- a/stellar-dotnet-sdk/responses/operations/ChangeTrustOperationResponse.cs
+++ b/stellar-dotnet-sdk/responses/operations/ChangeTrustOperationResponse.cs
@@ -51,6 +51,6 @@ namespace stellar_dotnet_sdk.responses.operations
         [JsonProperty(PropertyName = "trustor_muxed_id")]
         public ulong? TrustorMuxedID { get; private set; }
 
-        public Asset Asset => Asset.CreateNonNativeAsset(AssetType, AssetIssuer, AssetCode);
+        public AssetTypeCreditAlphaNum Asset => stellar_dotnet_sdk.Asset.CreateNonNativeAsset(AssetCode, AssetIssuer);
     }
 }

--- a/stellar-dotnet-sdk/responses/operations/ClawbackOperationResponse.cs
+++ b/stellar-dotnet-sdk/responses/operations/ClawbackOperationResponse.cs
@@ -77,6 +77,6 @@ namespace stellar_dotnet_sdk.responses.operations
         /// <summary>
         /// Asset representation (Using the values of the other fields)
         /// </summary>
-        public Asset Asset => Asset.CreateNonNativeAsset(AssetType, AssetIssuer, AssetCode);
+        public AssetTypeCreditAlphaNum Asset => stellar_dotnet_sdk.Asset.CreateNonNativeAsset(AssetCode, AssetIssuer);
     }
 }

--- a/stellar-dotnet-sdk/responses/operations/CreatePassiveOfferOperationResponse.cs
+++ b/stellar-dotnet-sdk/responses/operations/CreatePassiveOfferOperationResponse.cs
@@ -58,8 +58,8 @@ namespace stellar_dotnet_sdk.responses.operations
         [JsonProperty(PropertyName = "selling_asset_issuer")]
         public string SellingAssetIssuer { get; private set; }
 
-        public Asset BuyingAsset => Asset.CreateNonNativeAsset(BuyingAssetType, BuyingAssetIssuer, BuyingAssetCode);
+        public Asset BuyingAsset => Asset.Create(BuyingAssetType, BuyingAssetCode, BuyingAssetIssuer);
 
-        public Asset SellingAsset => Asset.CreateNonNativeAsset(SellingAssetType, SellingAssetIssuer, SellingAssetCode);
+        public Asset SellingAsset => Asset.Create(SellingAssetType, SellingAssetCode, SellingAssetIssuer);
     }
 }

--- a/stellar-dotnet-sdk/responses/operations/ManageOfferOperationResponse.cs
+++ b/stellar-dotnet-sdk/responses/operations/ManageOfferOperationResponse.cs
@@ -55,8 +55,8 @@ namespace stellar_dotnet_sdk.responses.operations
         [JsonProperty(PropertyName = "selling_asset_issuer")]
         public string SellingAssetIssuer { get; private set; }
 
-        public Asset BuyingAsset => Asset.CreateNonNativeAsset(BuyingAssetType, BuyingAssetIssuer, BuyingAssetCode);
+        public Asset BuyingAsset => Asset.Create(BuyingAssetType, BuyingAssetCode, BuyingAssetIssuer);
 
-        public Asset SellingAsset => Asset.CreateNonNativeAsset(SellingAssetType, SellingAssetIssuer, SellingAssetCode);
+        public Asset SellingAsset => Asset.Create(SellingAssetType, SellingAssetCode, SellingAssetIssuer);
     }
 }

--- a/stellar-dotnet-sdk/responses/operations/PathPaymentStrictReceiveOperationResponse.cs
+++ b/stellar-dotnet-sdk/responses/operations/PathPaymentStrictReceiveOperationResponse.cs
@@ -126,11 +126,11 @@ namespace stellar_dotnet_sdk.responses.operations
         /// <summary>
         /// Destination Asset
         /// </summary>
-        public Asset DestinationAsset => Asset.CreateNonNativeAsset(AssetType, AssetIssuer, AssetCode);
+        public AssetTypeCreditAlphaNum DestinationAsset => Asset.CreateNonNativeAsset(AssetCode, AssetIssuer);
 
         /// <summary>
         /// Source Asset
         /// </summary>
-        public Asset SourceAsset => Asset.CreateNonNativeAsset(SourceAssetType, SourceAssetIssuer, SourceAssetCode);
+        public AssetTypeCreditAlphaNum SourceAsset => Asset.CreateNonNativeAsset(SourceAssetCode, SourceAssetIssuer);
     }
 }

--- a/stellar-dotnet-sdk/responses/operations/PathPaymentStrictSendOperationResponse.cs
+++ b/stellar-dotnet-sdk/responses/operations/PathPaymentStrictSendOperationResponse.cs
@@ -126,11 +126,11 @@ namespace stellar_dotnet_sdk.responses.operations
         /// <summary>
         /// Destination Asset
         /// </summary>
-        public Asset DestinationAsset => Asset.CreateNonNativeAsset(AssetType, AssetIssuer, AssetCode);
+        public Asset DestinationAsset => Asset.Create(AssetType, AssetCode, AssetIssuer);
 
         /// <summary>
         /// Source Asset
         /// </summary>
-        public Asset SourceAsset => Asset.CreateNonNativeAsset(SourceAssetType, SourceAssetIssuer, SourceAssetCode);
+        public Asset SourceAsset => Asset.Create(SourceAssetType, SourceAssetCode, SourceAssetIssuer);
     }
 }

--- a/stellar-dotnet-sdk/responses/operations/PaymentOperationResponse.cs
+++ b/stellar-dotnet-sdk/responses/operations/PaymentOperationResponse.cs
@@ -64,7 +64,7 @@ namespace stellar_dotnet_sdk.responses.operations
         /// <summary>
         /// Account address that receives the payment.
         /// </summary>
-        public Asset Asset => Asset.CreateNonNativeAsset(AssetType, AssetIssuer, AssetCode);
+        public Asset Asset => Asset.Create(AssetType, AssetCode, AssetIssuer);
 
         public PaymentOperationResponse()
         {

--- a/stellar-dotnet-sdk/responses/operations/SetTrustlineFlagsOperationResponse.cs
+++ b/stellar-dotnet-sdk/responses/operations/SetTrustlineFlagsOperationResponse.cs
@@ -74,6 +74,6 @@ namespace stellar_dotnet_sdk.responses.operations
         /// <summary>
         /// Asset representation (Using the values of the other fields)
         /// </summary>
-        public Asset Asset => Asset.CreateNonNativeAsset(AssetType, AssetIssuer, AssetCode);
+        public AssetTypeCreditAlphaNum Asset => stellar_dotnet_sdk.Asset.CreateNonNativeAsset(AssetCode, AssetIssuer);
     }
 }


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ X ] Breaking change (fix or feature that would cause existing functionality to change)
- [ X ] I have read the **CONTRIBUTING** document.
- [ X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X ] I have added tests to cover my changes.
- [ X ] All new and existing tests passed.

These changes introduce a breaking change for the sake of (1) fixing a design flaw and (2) adding convenience when accessing an asset's code or issuer.  The biggest issue, imho, is the fact that CreateNonNativeAsset orders the "Code" parameter before the "Issuer" parameter.  The overloaded method that was removed, and likely used out in the field, orders the "Issuer" parameter before the "Code" parameter.  If one simply removes the "AssetType" parameter, they will get runtime errors.  However, if they have any unit tests with alphanum assets, it will be caught each and every time, since the an issuer is always more than 12 characters long.  All in all, I believe this breaking change does far more good than harm, and will almost certainly be caught on first test/debug run.