### PR TITLE
Fix for missing fee bump result (issue 388)

### DIFF
--- a/stellar-dotnet-sdk-test/operations/FeeBumpOperationTest.cs
+++ b/stellar-dotnet-sdk-test/operations/FeeBumpOperationTest.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using stellar_dotnet_sdk;
 using xdrSDK = stellar_dotnet_sdk.xdr;
 using System.Threading.Tasks;
@@ -30,11 +31,8 @@ public class FeeBumpOperationTest
 
         var sourceAccount = await server.Accounts.Account(sourceKeyPair.AccountId);
 
-        const uint maxFee = 2000000u;
-
         var transactionBuilder = new TransactionBuilder(sourceAccount);
-        transactionBuilder.SetFee(maxFee);
-            
+
         var paymentOperationBuilder = new PaymentOperation.Builder(
             sponsorKeyPair,
             new AssetTypeNative(),
@@ -48,8 +46,7 @@ public class FeeBumpOperationTest
 
         var feeBumpTransaction = TransactionBuilder.BuildFeeBumpTransaction(
             sponsorKeyPair,
-            transaction,
-            maxFee
+            transaction
         );
         feeBumpTransaction.Sign(sponsorKeyPair);
 
@@ -80,6 +77,57 @@ public class FeeBumpOperationTest
 
         var sourceAccount = await server.Accounts.Account(sourceKeyPair.AccountId);
 
+        var transactionBuilder = new TransactionBuilder(sourceAccount);
+            
+        var paymentOperationBuilder = new PaymentOperation.Builder(
+            sponsorKeyPair,
+            new AssetTypeNative(),
+            "100000"
+        );
+        transactionBuilder.AddOperation(
+            paymentOperationBuilder.Build()
+        );
+        var transaction = transactionBuilder.Build();
+        transaction.Sign(sourceKeyPair);
+
+        var feeBumpTransaction = TransactionBuilder.BuildFeeBumpTransaction(
+            sponsorKeyPair,
+            transaction
+        );
+        feeBumpTransaction.Sign(sponsorKeyPair);
+
+        var response = await server.SubmitTransaction(feeBumpTransaction);
+            
+        Assert.IsFalse(response.IsSuccess());
+            
+        var result = response.Result as FeeBumpTransactionResultFailed;
+        Assert.IsNotNull(result);
+            
+        var innerResult = result.InnerResultPair.Result as TransactionResultFailed;
+        Assert.IsNotNull(innerResult);
+        Assert.IsInstanceOfType(innerResult.Results[0], typeof(PaymentUnderfunded));
+    }
+    
+    [TestMethod]
+    public async Task InsufficientFee()
+    {
+        Network.UseTestNetwork();
+        using var server = new Server("https://horizon-testnet.stellar.org");
+
+        var sourceKeyPair = KeyPair.Random();
+        var sponsorKeyPair = KeyPair.Random();
+
+        await Task.WhenAll(
+            server.TestNetFriendBot
+                .FundAccount(sourceKeyPair.AccountId)
+                .Execute(),
+            server.TestNetFriendBot
+                .FundAccount(sponsorKeyPair.AccountId)
+                .Execute()
+        );
+
+        var sourceAccount = await server.Accounts.Account(sourceKeyPair.AccountId);
+
         const uint maxFee = 2000000u;
 
         var transactionBuilder = new TransactionBuilder(sourceAccount);
@@ -88,7 +136,60 @@ public class FeeBumpOperationTest
         var paymentOperationBuilder = new PaymentOperation.Builder(
             sponsorKeyPair,
             new AssetTypeNative(),
-            "100000"
+            "1000"
+        );
+        transactionBuilder.AddOperation(
+            paymentOperationBuilder.Build()
+        );
+        transactionBuilder.AddOperation(
+            paymentOperationBuilder.Build()
+        );
+        var transaction = transactionBuilder.Build();
+        transaction.Sign(sourceKeyPair);
+
+        var exception = Assert.ThrowsException<Exception>(() => {
+            TransactionBuilder.BuildFeeBumpTransaction(
+                sponsorKeyPair,
+                transaction,
+                maxFee / 2
+            );
+        });
+
+        Assert.AreEqual($"Invalid fee, it should be at least {maxFee} stroops", exception.Message);
+    }
+
+    [TestMethod]
+    public async Task SufficientFee()
+    {
+        Network.UseTestNetwork();
+        using var server = new Server("https://horizon-testnet.stellar.org");
+
+        var sourceKeyPair = KeyPair.Random();
+        var sponsorKeyPair = KeyPair.Random();
+
+        await Task.WhenAll(
+            server.TestNetFriendBot
+                .FundAccount(sourceKeyPair.AccountId)
+                .Execute(),
+            server.TestNetFriendBot
+                .FundAccount(sponsorKeyPair.AccountId)
+                .Execute()
+        );
+
+        var sourceAccount = await server.Accounts.Account(sourceKeyPair.AccountId);
+
+        const uint maxFee = 2000000u;
+
+        var transactionBuilder = new TransactionBuilder(sourceAccount);
+        transactionBuilder.SetFee(maxFee);
+            
+        var paymentOperationBuilder = new PaymentOperation.Builder(
+            sponsorKeyPair,
+            new AssetTypeNative(),
+            "1000"
+        );
+        transactionBuilder.AddOperation(
+            paymentOperationBuilder.Build()
         );
         transactionBuilder.AddOperation(
             paymentOperationBuilder.Build()
@@ -104,14 +205,9 @@ public class FeeBumpOperationTest
         feeBumpTransaction.Sign(sponsorKeyPair);
 
         var response = await server.SubmitTransaction(feeBumpTransaction);
-            
-        Assert.IsFalse(response.IsSuccess());
-            
-        var result = response.Result as FeeBumpTransactionResultFailed;
-        Assert.IsNotNull(result);
-            
-        var innerResult = result.InnerResultPair.Result as TransactionResultFailed;
-        Assert.IsNotNull(innerResult);
-        Assert.IsInstanceOfType(innerResult.Results[0], typeof(PaymentUnderfunded));
+
+        Assert.IsTrue(response.IsSuccess());
+        Assert.IsFalse(string.IsNullOrEmpty(response.Hash));
+        Assert.IsInstanceOfType(response.Result, typeof(FeeBumpTransactionResultSuccess));
     }
 }

--- a/stellar-dotnet-sdk-test/operations/FeeBumpOperationTest.cs
+++ b/stellar-dotnet-sdk-test/operations/FeeBumpOperationTest.cs
@@ -1,0 +1,117 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using stellar_dotnet_sdk;
+using xdrSDK = stellar_dotnet_sdk.xdr;
+using System.Threading.Tasks;
+using stellar_dotnet_sdk.responses;
+using stellar_dotnet_sdk.responses.results;
+
+namespace stellar_dotnet_sdk_test.operations;
+
+[TestClass]
+public class FeeBumpOperationTest
+{
+    [TestMethod]
+    public async Task TransactionResultSuccess()
+    {
+        Network.UseTestNetwork();
+        using var server = new Server("https://horizon-testnet.stellar.org");
+
+        var sourceKeyPair = KeyPair.Random();
+        var sponsorKeyPair = KeyPair.Random();
+
+        await Task.WhenAll(
+            server.TestNetFriendBot
+                .FundAccount(sourceKeyPair.AccountId)
+                .Execute(),
+            server.TestNetFriendBot
+                .FundAccount(sponsorKeyPair.AccountId)
+                .Execute()
+        );
+
+        var sourceAccount = await server.Accounts.Account(sourceKeyPair.AccountId);
+
+        const uint maxFee = 2000000u;
+
+        var transactionBuilder = new TransactionBuilder(sourceAccount);
+        transactionBuilder.SetFee(maxFee);
+            
+        var paymentOperationBuilder = new PaymentOperation.Builder(
+            sponsorKeyPair,
+            new AssetTypeNative(),
+            "10"
+        );
+        transactionBuilder.AddOperation(
+            paymentOperationBuilder.Build()
+        );
+        var transaction = transactionBuilder.Build();
+        transaction.Sign(sourceKeyPair);
+
+        var feeBumpTransaction = TransactionBuilder.BuildFeeBumpTransaction(
+            sponsorKeyPair,
+            transaction,
+            maxFee
+        );
+        feeBumpTransaction.Sign(sponsorKeyPair);
+
+        var response = await server.SubmitTransaction(feeBumpTransaction);
+
+        Assert.IsTrue(response.IsSuccess());
+        Assert.IsFalse(string.IsNullOrEmpty(response.Hash));
+        Assert.IsInstanceOfType(response.Result, typeof(FeeBumpTransactionResultSuccess));
+    }
+        
+    [TestMethod]
+    public async Task TransactionResultFailed()
+    {
+        Network.UseTestNetwork();
+        using var server = new Server("https://horizon-testnet.stellar.org");
+
+        var sourceKeyPair = KeyPair.Random();
+        var sponsorKeyPair = KeyPair.Random();
+
+        await Task.WhenAll(
+            server.TestNetFriendBot
+                .FundAccount(sourceKeyPair.AccountId)
+                .Execute(),
+            server.TestNetFriendBot
+                .FundAccount(sponsorKeyPair.AccountId)
+                .Execute()
+        );
+
+        var sourceAccount = await server.Accounts.Account(sourceKeyPair.AccountId);
+
+        const uint maxFee = 2000000u;
+
+        var transactionBuilder = new TransactionBuilder(sourceAccount);
+        transactionBuilder.SetFee(maxFee);
+            
+        var paymentOperationBuilder = new PaymentOperation.Builder(
+            sponsorKeyPair,
+            new AssetTypeNative(),
+            "100000"
+        );
+        transactionBuilder.AddOperation(
+            paymentOperationBuilder.Build()
+        );
+        var transaction = transactionBuilder.Build();
+        transaction.Sign(sourceKeyPair);
+
+        var feeBumpTransaction = TransactionBuilder.BuildFeeBumpTransaction(
+            sponsorKeyPair,
+            transaction,
+            maxFee
+        );
+        feeBumpTransaction.Sign(sponsorKeyPair);
+
+        var response = await server.SubmitTransaction(feeBumpTransaction);
+            
+        Assert.IsFalse(response.IsSuccess());
+            
+        var result = response.Result as FeeBumpTransactionResultFailed;
+        Assert.IsNotNull(result);
+            
+        var innerResult = result.InnerResultPair.Result as TransactionResultFailed;
+        Assert.IsNotNull(innerResult);
+        Assert.IsInstanceOfType(innerResult.Results[0], typeof(PaymentUnderfunded));
+    }
+}

--- a/stellar-dotnet-sdk/responses/FeeBumpTransactionResultFailed.cs
+++ b/stellar-dotnet-sdk/responses/FeeBumpTransactionResultFailed.cs
@@ -1,0 +1,11 @@
+namespace stellar_dotnet_sdk.responses;
+
+/// <summary>
+/// One of the operations in the inner transaction failed (none were applied).
+/// </summary>
+public class FeeBumpTransactionResultFailed : TransactionResult
+{
+    public override bool IsSuccess => false;
+
+    public InnerTransactionResultPair InnerResultPair { get; set; }
+}

--- a/stellar-dotnet-sdk/responses/FeeBumpTransactionResultSuccess.cs
+++ b/stellar-dotnet-sdk/responses/FeeBumpTransactionResultSuccess.cs
@@ -1,0 +1,11 @@
+namespace stellar_dotnet_sdk.responses;
+
+/// <summary>
+/// All operations in the inner transaction succeeded.
+/// </summary>
+public class FeeBumpTransactionResultSuccess : TransactionResult
+{
+    public override bool IsSuccess => true;
+
+    public InnerTransactionResultPair InnerResultPair { get; set; }
+}

--- a/stellar-dotnet-sdk/responses/InnerTransactionResultPair.cs
+++ b/stellar-dotnet-sdk/responses/InnerTransactionResultPair.cs
@@ -1,0 +1,31 @@
+using System;
+using stellar_dotnet_sdk.xdr;
+
+namespace stellar_dotnet_sdk.responses;
+
+public class InnerTransactionResultPair
+{
+    public string TransactionHash { get; set; }
+        
+    public TransactionResult Result { get; set; }
+        
+    public static InnerTransactionResultPair FromXdr(string encoded)
+    {
+        byte[] bytes = Convert.FromBase64String(encoded);
+        var result = xdr.InnerTransactionResultPair.Decode(new xdr.XdrDataInputStream(bytes));
+        return FromXdr(result);
+    }
+
+    public static InnerTransactionResultPair FromXdr(xdr.InnerTransactionResultPair result)
+    {
+        var writer = new XdrDataOutputStream();
+        xdr.InnerTransactionResult.Encode(writer, result.Result);
+        var xdrTransaction = Convert.ToBase64String(writer.ToArray());
+
+        return new InnerTransactionResultPair
+        {
+            TransactionHash = Convert.ToBase64String(result.TransactionHash.InnerValue),
+            Result = TransactionResult.FromXdr(xdrTransaction),
+        };
+    }
+}

--- a/stellar-dotnet-sdk/responses/TransactionResult.cs
+++ b/stellar-dotnet-sdk/responses/TransactionResult.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using stellar_dotnet_sdk.responses.results;
+using stellar_dotnet_sdk.xdr;
+using OperationResult = stellar_dotnet_sdk.responses.results.OperationResult;
 
 namespace stellar_dotnet_sdk.responses
 {
@@ -88,6 +89,18 @@ namespace stellar_dotnet_sdk.responses
                     return new TransactionResultInternalError
                     {
                         FeeCharged = feeCharged
+                    };
+                case xdr.TransactionResultCode.TransactionResultCodeEnum.txFEE_BUMP_INNER_SUCCESS:
+                    return new FeeBumpTransactionResultSuccess
+                    {
+                        FeeCharged = feeCharged,
+                        InnerResultPair = InnerTransactionResultPair.FromXdr(result.Result.InnerResultPair),
+                    };
+                case xdr.TransactionResultCode.TransactionResultCodeEnum.txFEE_BUMP_INNER_FAILED:
+                    return new FeeBumpTransactionResultFailed
+                    {
+                        FeeCharged = feeCharged,
+                        InnerResultPair = InnerTransactionResultPair.FromXdr(result.Result.InnerResultPair),
                     };
                 default:
                     throw new SystemException("Unknown TransactionResult type");

--- a/stellar-dotnet-sdk/responses/TransactionResultSuccess.cs
+++ b/stellar-dotnet-sdk/responses/TransactionResultSuccess.cs
@@ -4,7 +4,7 @@ using stellar_dotnet_sdk.responses.results;
 namespace stellar_dotnet_sdk.responses
 {
     /// <summary>
-    /// All operations succeded.
+    /// All operations succeeded.
     /// </summary>
     public class TransactionResultSuccess : TransactionResult
     {


### PR DESCRIPTION
Fix for [issue 388](https://github.com/elucidsoft/dotnet-stellar-sdk/issues/388).

Also fixed the fee bump fee according to the Stellar documentation.
https://developers.stellar.org/docs/encyclopedia/fee-bump-transactions#fee

It states that the fee set on the fee bump transaction should be the amount of stopen that you would like to pay for executing only the fee bump operation which is 1 operation. So this should be independent from the inner transaction.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
